### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nicholas Watson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,78 @@
-# README
+# Prose
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+A self-hosted blogging platform built with Ruby on Rails 8.1 and the Solid stack. Prose runs entirely on SQLite — no Redis, Postgres, or external services required.
 
-Things you may want to cover:
+## Features
 
-* Ruby version
+- Rich text editing with [Lexxy](https://github.com/basecamp/lexxy)
+- Categories and tags for organizing content
+- Subscriber management with email notifications
+- RSS feed and sitemap generation
+- Post scheduling and analytics (views, loves, comments)
+- Customizable typography with live preview
+- Admin dashboard for managing posts, comments, and subscribers
+- SEO-friendly slugged URLs
 
-* System dependencies
+## Tech Stack
 
-* Configuration
+- **Ruby** 3.4.4 / **Rails** 8.1
+- **SQLite3** for all persistence
+- **Solid Queue** — database-backed background jobs
+- **Solid Cache** — database-backed caching
+- **Solid Cable** — database-backed WebSockets
+- **Hotwire** (Turbo + Stimulus) — SPA-like interactivity
+- **Tailwind CSS** — utility-first styling
+- **Propshaft** — asset pipeline
+- **ImportMap** — JavaScript modules without bundling
+- **Kamal** — Docker-based deployment
 
-* Database creation
+## Getting Started
 
-* Database initialization
+### Prerequisites
 
-* How to run the test suite
+- Ruby 3.4.4
+- SQLite3
 
-* Services (job queues, cache servers, search engines, etc.)
+### Setup
 
-* Deployment instructions
+```bash
+bin/setup              # Install dependencies, prepare database, start server
+bin/setup --skip-server # Setup without starting the server
+```
 
-* ...
+### Development
+
+```bash
+bin/dev                # Start dev server (Puma + Tailwind watcher) on port 3000
+```
+
+Visit `http://localhost:3000/admin/setup` to create your admin account.
+
+### Testing
+
+```bash
+bin/rails test         # Run all tests
+bin/rails test:system  # Run system (browser) tests
+```
+
+### Linting and Security
+
+```bash
+bin/ci                 # Run full CI locally (setup, lint, security, tests)
+bin/rubocop            # Ruby linting
+bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error  # Security scan
+bin/bundler-audit      # Gem vulnerability audit
+bin/importmap audit    # JS dependency audit
+```
+
+## Deployment
+
+Prose deploys as a Docker container via [Kamal](https://kamal-deploy.org). SQLite databases are persisted through a volume mount. Solid Queue runs in-process with Puma.
+
+```bash
+SOLID_QUEUE_IN_PUMA=true
+```
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Replace the Rails placeholder README with project documentation covering features, tech stack, setup instructions, testing, and deployment
- Add MIT license file

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify LICENSE is recognized by GitHub as MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)