### PR TITLE
Fix post links in infinite scroll showing Content missing

### DIFF
--- a/app/views/posts/_post_page.html.erb
+++ b/app/views/posts/_post_page.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <% if next_page %>
-    <%= turbo_frame_tag "posts_page_#{next_page}" do %>
+    <%= turbo_frame_tag "posts_page_#{next_page}", target: "_top" do %>
       <div data-infinite-scroll-target="sentinel">
         <%= link_to "Load more", posts_path(page: next_page, q: query), data: { turbo_frame: "posts_page_#{next_page}" }, class: "hidden" %>
       </div>


### PR DESCRIPTION
## Summary

- Add `target: "_top"` to the inner sentinel turbo frame in `_post_page.html.erb`
- Posts loaded via infinite scroll now correctly navigate to the post page instead of showing "Content missing"

The root cause was that the inner `turbo_frame_tag` for the next-page sentinel lacked `target: "_top"`. When new pages loaded into this frame, all links (post titles, categories) inherited the frame context and tried to navigate within it. Since the post show page has no matching `<turbo-frame>`, Turbo displayed "Content missing".

The "Load more" link is unaffected because it has an explicit `data-turbo-frame` attribute targeting the correct frame.

## Test plan

- [x] All unit tests pass (`bin/rails test`)
- [ ] Manual: Scroll to load additional pages on the homepage
- [ ] Manual: Click a post title loaded via infinite scroll — navigates to the full post page
- [ ] Manual: Click a category link loaded via infinite scroll — navigates to the category page

🤖 Generated with [Claude Code](https://claude.com/claude-code)