### PR TITLE
Restructure typography settings UI

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -9,6 +9,27 @@
   --color-ink-blue: #3d5a80;
 }
 
+/* Range slider component */
+input[data-range-slider-target="input"] {
+  @apply h-2 rounded-full outline-none cursor-pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[data-range-slider-target="input"]::-webkit-slider-thumb {
+  @apply size-5.5 rounded-full bg-white border-2 border-blue-500 shadow-sm cursor-pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[data-range-slider-target="input"]::-moz-range-thumb {
+  @apply size-5.5 rounded-full bg-white border-2 border-blue-500 shadow-sm cursor-pointer;
+}
+
+input[data-range-slider-target="input"]::-moz-range-track {
+  @apply h-2 rounded-full bg-transparent;
+}
+
 /* Focused editor: strip rich-text editor chrome */
 .editor-writing-area lexxy-editor {
   border: none;

--- a/app/javascript/controllers/range_slider_controller.js
+++ b/app/javascript/controllers/range_slider_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "value"]
+  static values = { suffix: { type: String, default: "" } }
+
+  connect() {
+    this.updateDisplay()
+  }
+
+  updateDisplay() {
+    const input = this.inputTarget
+    const percent = ((input.value - input.min) / (input.max - input.min)) * 100
+
+    input.style.background = `linear-gradient(to right, #3b82f6 ${percent}%, #e5e7eb ${percent}%)`
+    this.valueTarget.textContent = `${input.value}${this.suffixValue}`
+  }
+}

--- a/app/javascript/controllers/typography_preview_controller.js
+++ b/app/javascript/controllers/typography_preview_controller.js
@@ -4,7 +4,6 @@ export default class extends Controller {
   static targets = [
     "headingFont", "subtitleFont", "bodyFont",
     "headingSize", "subtitleSize", "bodySize",
-    "headingSizeValue", "subtitleSizeValue", "bodySizeValue",
     "previewHeading", "previewSubtitle", "previewBody"
   ]
 
@@ -26,11 +25,6 @@ export default class extends Controller {
     this.#loadFont(headingFont)
     this.#loadFont(subtitleFont)
     this.#loadFont(bodyFont)
-
-    // Update size labels
-    this.headingSizeValueTarget.textContent = `${headingSize}rem`
-    this.subtitleSizeValueTarget.textContent = `${subtitleSize}rem`
-    this.bodySizeValueTarget.textContent = `${bodySize}rem`
 
     // Update preview styles
     this.previewHeadingTarget.style.fontFamily = `"${headingFont}"`

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "Settings — #{site_name}") %>
 
-<div class="max-w-2xl">
+<div class="max-w-4xl">
   <h1 class="text-2xl font-bold text-gray-900">Site Settings</h1>
   <p class="mt-1 text-sm text-gray-600">Configure your site name, description, and default social sharing image.</p>
 
@@ -48,73 +48,77 @@
       <legend class="text-lg font-semibold text-gray-900">Typography</legend>
       <p class="mt-1 text-sm text-gray-600">Choose fonts and sizes for your site. Changes apply to all public pages.</p>
 
-      <div class="mt-4 grid gap-6 sm:grid-cols-3">
-        <div>
-          <%= f.label :heading_font, "Heading font", class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.select :heading_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                  class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                  data: { typography_preview_target: "headingFont", action: "typography-preview#update" } %>
+      <div class="mt-6 grid grid-cols-1 gap-8 lg:grid-cols-2">
+        <%# Left column — Controls %>
+        <div class="space-y-6">
+          <%# Heading group %>
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Heading</h3>
+            <div class="mt-3 space-y-4">
+              <div>
+                <%= f.label :heading_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
+                <div class="mt-2">
+                  <%= f.select :heading_font, SiteSetting::Typography::GOOGLE_FONTS, {},
+                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
+                        data: { typography_preview_target: "headingFont", action: "typography-preview#update" } %>
+                </div>
+              </div>
+              <%= render "shared/range_slider", form: f, field: :heading_font_size, label: "Font size",
+                    min: 0.75, max: 6, step: 0.125, suffix: "rem",
+                    data: { typography_preview_target: "headingSize", action: "input->typography-preview#update" } %>
+            </div>
+          </div>
+
+          <hr class="border-gray-200">
+
+          <%# Subtitle group %>
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Subtitle</h3>
+            <div class="mt-3 space-y-4">
+              <div>
+                <%= f.label :subtitle_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
+                <div class="mt-2">
+                  <%= f.select :subtitle_font, SiteSetting::Typography::GOOGLE_FONTS, {},
+                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
+                        data: { typography_preview_target: "subtitleFont", action: "typography-preview#update" } %>
+                </div>
+              </div>
+              <%= render "shared/range_slider", form: f, field: :subtitle_font_size, label: "Font size",
+                    min: 0.75, max: 6, step: 0.125, suffix: "rem",
+                    data: { typography_preview_target: "subtitleSize", action: "input->typography-preview#update" } %>
+            </div>
+          </div>
+
+          <hr class="border-gray-200">
+
+          <%# Body group %>
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">Body</h3>
+            <div class="mt-3 space-y-4">
+              <div>
+                <%= f.label :body_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
+                <div class="mt-2">
+                  <%= f.select :body_font, SiteSetting::Typography::GOOGLE_FONTS, {},
+                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
+                        data: { typography_preview_target: "bodyFont", action: "typography-preview#update" } %>
+                </div>
+              </div>
+              <%= render "shared/range_slider", form: f, field: :body_font_size, label: "Font size",
+                    min: 0.75, max: 6, step: 0.125, suffix: "rem",
+                    data: { typography_preview_target: "bodySize", action: "input->typography-preview#update" } %>
+            </div>
           </div>
         </div>
 
-        <div>
-          <%= f.label :subtitle_font, "Subtitle font", class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.select :subtitle_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                  class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                  data: { typography_preview_target: "subtitleFont", action: "typography-preview#update" } %>
+        <%# Right column — Sticky preview %>
+        <div class="lg:sticky lg:top-20 lg:self-start">
+          <div class="rounded-md border border-gray-200 bg-white p-6">
+            <p class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">Preview</p>
+            <h2 data-typography-preview-target="previewHeading" class="text-3xl font-bold">The quick brown fox</h2>
+            <p data-typography-preview-target="previewSubtitle" class="mt-1 text-lg text-gray-600">Jumps over the lazy dog</p>
+            <p data-typography-preview-target="previewBody" class="mt-3 text-gray-700">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
           </div>
         </div>
-
-        <div>
-          <%= f.label :body_font, "Body font", class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.select :body_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                  class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                  data: { typography_preview_target: "bodyFont", action: "typography-preview#update" } %>
-          </div>
-        </div>
-      </div>
-
-      <div class="mt-6 grid gap-6 sm:grid-cols-3">
-        <div>
-          <%= f.label :heading_font_size, class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2 flex items-center gap-3">
-            <%= f.range_field :heading_font_size, min: 0.75, max: 6, step: 0.125,
-                  class: "flex-1",
-                  data: { typography_preview_target: "headingSize", action: "input->typography-preview#update" } %>
-            <span class="w-16 text-right text-sm text-gray-600" data-typography-preview-target="headingSizeValue"><%= @site_setting.heading_font_size %>rem</span>
-          </div>
-        </div>
-
-        <div>
-          <%= f.label :subtitle_font_size, class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2 flex items-center gap-3">
-            <%= f.range_field :subtitle_font_size, min: 0.75, max: 6, step: 0.125,
-                  class: "flex-1",
-                  data: { typography_preview_target: "subtitleSize", action: "input->typography-preview#update" } %>
-            <span class="w-16 text-right text-sm text-gray-600" data-typography-preview-target="subtitleSizeValue"><%= @site_setting.subtitle_font_size %>rem</span>
-          </div>
-        </div>
-
-        <div>
-          <%= f.label :body_font_size, class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2 flex items-center gap-3">
-            <%= f.range_field :body_font_size, min: 0.75, max: 6, step: 0.125,
-                  class: "flex-1",
-                  data: { typography_preview_target: "bodySize", action: "input->typography-preview#update" } %>
-            <span class="w-16 text-right text-sm text-gray-600" data-typography-preview-target="bodySizeValue"><%= @site_setting.body_font_size %>rem</span>
-          </div>
-        </div>
-      </div>
-
-      <%# Live preview %>
-      <div class="mt-6 rounded-md border border-gray-200 bg-white p-6">
-        <p class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">Preview</p>
-        <h2 data-typography-preview-target="previewHeading" class="text-3xl font-bold">The quick brown fox</h2>
-        <p data-typography-preview-target="previewSubtitle" class="mt-1 text-lg text-gray-600">Jumps over the lazy dog</p>
-        <p data-typography-preview-target="previewBody" class="mt-3 text-gray-700">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
       </div>
     </fieldset>
 

--- a/app/views/shared/_range_slider.html.erb
+++ b/app/views/shared/_range_slider.html.erb
@@ -1,0 +1,15 @@
+<%# locals: (form:, field:, label:, min:, max:, step:, suffix: "", data: {}) %>
+<%
+  extra_action = data.delete(:action)
+  own_action = "input->range-slider#updateDisplay"
+  merged_action = extra_action ? "#{own_action} #{extra_action}" : own_action
+%>
+<div data-controller="range-slider" data-range-slider-suffix-value="<%= suffix %>">
+  <div class="flex justify-between mb-2">
+    <%= form.label field, label, class: "block text-sm font-medium text-gray-900" %>
+    <span class="text-sm font-medium text-blue-600" data-range-slider-target="value"><%= form.object.send(field) %><%= suffix %></span>
+  </div>
+  <%= form.range_field field, min: min, max: max, step: step,
+        class: "w-full",
+        data: { range_slider_target: "input", action: merged_action }.merge(data) %>
+</div>


### PR DESCRIPTION
## Summary
- Replace flat 3-column grid typography controls with a two-column layout: grouped controls (Heading/Subtitle/Body) on the left, sticky live preview on the right
- Extract range slider into a reusable Stimulus controller (`range_slider_controller.js`) and shared partial (`shared/_range_slider.html.erb`) with styled blue track fill and circular thumb
- Move slider styles from injected JS into Tailwind CSS using `@apply` for maintainability
- Simplify `typography_preview_controller.js` by removing size value display targets (now handled by the range slider controller)

## Test plan
- [x] All unit tests pass (`bin/rails test` — 255 pass, 0 failures)
- [x] RuboCop clean (`bin/rubocop` — 0 offenses)
- [x] Desktop: typography section shows two-column layout with sticky preview
- [x] Mobile: falls back to single column with preview below controls
- [x] Range sliders show blue fill track, circular thumb, and live value display
- [x] Moving a slider updates both its displayed value and the live preview
- [x] Font dropdown changes update the preview
- [x] Form submits correctly with all typography values

🤖 Generated with [Claude Code](https://claude.com/claude-code)