### PR TITLE
Add custom select dropdown component

### DIFF
--- a/app/javascript/controllers/custom_select_controller.js
+++ b/app/javascript/controllers/custom_select_controller.js
@@ -1,0 +1,236 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["select", "trigger", "triggerText", "dropdown"]
+
+  connect() {
+    this.buildOptions()
+    this.syncTriggerText()
+    this.handleOutsideClick = this.handleOutsideClick.bind(this)
+    this.handleKeydown = this.handleKeydown.bind(this)
+    this.searchString = ""
+    this.searchTimeout = null
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.handleOutsideClick)
+    document.removeEventListener("keydown", this.handleKeydown)
+  }
+
+  buildOptions() {
+    const dropdown = this.dropdownTarget
+    dropdown.innerHTML = ""
+
+    const options = this.selectTarget.options
+    for (let i = 0; i < options.length; i++) {
+      const option = options[i]
+      const li = document.createElement("li")
+      li.setAttribute("role", "option")
+      li.setAttribute("data-value", option.value)
+      li.setAttribute("data-action", "click->custom-select#pick")
+      li.className = this.optionClasses(option.value === this.selectTarget.value)
+      li.innerHTML = `
+        <span class="block truncate">${this.escapeHtml(option.textContent)}</span>
+        <span class="absolute inset-y-0 right-0 flex items-center pr-3 ${option.value === this.selectTarget.value ? "text-white" : "hidden"}">
+          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+          </svg>
+        </span>
+      `
+      dropdown.appendChild(li)
+    }
+  }
+
+  optionClasses(selected) {
+    const base = "relative cursor-pointer select-none py-2 pl-3 pr-9 transition-colors"
+    if (selected) {
+      return `${base} bg-blue-600 text-white`
+    }
+    return `${base} text-gray-900 hover:bg-gray-100`
+  }
+
+  syncTriggerText() {
+    const selected = this.selectTarget.options[this.selectTarget.selectedIndex]
+    if (selected) {
+      this.triggerTextTarget.textContent = selected.textContent
+    }
+  }
+
+  toggle() {
+    if (this.isOpen()) {
+      this.close()
+    } else {
+      this.open()
+    }
+  }
+
+  open() {
+    const dropdown = this.dropdownTarget
+    dropdown.classList.remove("hidden")
+    // Force reflow before adding transition classes
+    dropdown.offsetHeight // eslint-disable-line no-unused-expressions
+    dropdown.classList.remove("opacity-0", "scale-95")
+    dropdown.classList.add("opacity-100", "scale-100")
+
+    document.addEventListener("click", this.handleOutsideClick)
+    document.addEventListener("keydown", this.handleKeydown)
+
+    // Scroll selected option into view
+    const selected = dropdown.querySelector('[class*="bg-blue-600"]')
+    if (selected) {
+      selected.scrollIntoView({ block: "nearest" })
+    }
+
+    this.focusedIndex = this.selectedOptionIndex()
+  }
+
+  close() {
+    const dropdown = this.dropdownTarget
+    dropdown.classList.remove("opacity-100", "scale-100")
+    dropdown.classList.add("opacity-0", "scale-95")
+
+    const onTransitionEnd = () => {
+      dropdown.classList.add("hidden")
+      dropdown.removeEventListener("transitionend", onTransitionEnd)
+    }
+    dropdown.addEventListener("transitionend", onTransitionEnd)
+
+    document.removeEventListener("click", this.handleOutsideClick)
+    document.removeEventListener("keydown", this.handleKeydown)
+  }
+
+  isOpen() {
+    return !this.dropdownTarget.classList.contains("hidden")
+  }
+
+  pick(event) {
+    const li = event.target.closest("li")
+    if (!li) return
+
+    const value = li.getAttribute("data-value")
+    this.selectValue(value)
+    this.close()
+  }
+
+  selectValue(value) {
+    this.selectTarget.value = value
+    this.selectTarget.dispatchEvent(new Event("change", { bubbles: true }))
+
+    this.syncTriggerText()
+    this.updateOptionStyles()
+  }
+
+  updateOptionStyles() {
+    const items = this.dropdownTarget.querySelectorAll("li")
+    const currentValue = this.selectTarget.value
+
+    items.forEach((li) => {
+      const isSelected = li.getAttribute("data-value") === currentValue
+      li.className = this.optionClasses(isSelected)
+
+      const checkmark = li.querySelector("span:last-child")
+      if (isSelected) {
+        checkmark.classList.remove("hidden")
+        checkmark.classList.add("text-white")
+      } else {
+        checkmark.classList.add("hidden")
+      }
+    })
+  }
+
+  handleOutsideClick(event) {
+    if (!this.element.contains(event.target)) {
+      this.close()
+    }
+  }
+
+  handleKeydown(event) {
+    const items = this.dropdownTarget.querySelectorAll("li")
+    if (items.length === 0) return
+
+    switch (event.key) {
+      case "Escape":
+        event.preventDefault()
+        this.close()
+        this.triggerTarget.focus()
+        break
+      case "ArrowDown":
+        event.preventDefault()
+        this.focusedIndex = Math.min((this.focusedIndex ?? -1) + 1, items.length - 1)
+        this.highlightItem(items)
+        break
+      case "ArrowUp":
+        event.preventDefault()
+        this.focusedIndex = Math.max((this.focusedIndex ?? 1) - 1, 0)
+        this.highlightItem(items)
+        break
+      case "Home":
+        event.preventDefault()
+        this.focusedIndex = 0
+        this.highlightItem(items)
+        break
+      case "End":
+        event.preventDefault()
+        this.focusedIndex = items.length - 1
+        this.highlightItem(items)
+        break
+      case "Enter":
+      case " ":
+        event.preventDefault()
+        if (this.focusedIndex != null && items[this.focusedIndex]) {
+          const value = items[this.focusedIndex].getAttribute("data-value")
+          this.selectValue(value)
+          this.close()
+          this.triggerTarget.focus()
+        }
+        break
+      default:
+        // Type-ahead search
+        if (event.key.length === 1) {
+          this.typeAhead(event.key, items)
+        }
+        break
+    }
+  }
+
+  typeAhead(char, items) {
+    clearTimeout(this.searchTimeout)
+    this.searchString += char.toLowerCase()
+    this.searchTimeout = setTimeout(() => { this.searchString = "" }, 500)
+
+    for (let i = 0; i < items.length; i++) {
+      const text = items[i].querySelector("span").textContent.toLowerCase()
+      if (text.startsWith(this.searchString)) {
+        this.focusedIndex = i
+        this.highlightItem(items)
+        break
+      }
+    }
+  }
+
+  highlightItem(items) {
+    items.forEach((li, i) => {
+      if (i === this.focusedIndex) {
+        li.classList.add("ring-2", "ring-inset", "ring-blue-400")
+        li.scrollIntoView({ block: "nearest" })
+      } else {
+        li.classList.remove("ring-2", "ring-inset", "ring-blue-400")
+      }
+    })
+  }
+
+  selectedOptionIndex() {
+    const items = this.dropdownTarget.querySelectorAll("li")
+    const currentValue = this.selectTarget.value
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].getAttribute("data-value") === currentValue) return i
+    }
+    return 0
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -45,10 +45,8 @@
     <div class="space-y-6 p-6">
       <div>
         <%= f.label :status, class: "block text-sm font-medium text-gray-900" %>
-        <div class="mt-2">
-          <%= f.select :status, Post.statuses.keys.map { |s| [s.capitalize, s] }, {},
-                class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm" %>
-        </div>
+        <%= render "shared/custom_select", form: f, field: :status,
+              options: Post.statuses.keys.map { |s| [s.capitalize, s] } %>
       </div>
 
       <div>
@@ -72,11 +70,9 @@
 
       <div>
         <%= f.label :category_id, "Category", class: "block text-sm font-medium text-gray-900" %>
-        <div class="mt-2">
-          <%= f.collection_select :category_id, Category.ordered, :id, :name,
-                { include_blank: "No category" },
-                class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm" %>
-        </div>
+        <%= render "shared/custom_select", form: f, field: :category_id,
+              collection: Category.ordered, value_method: :id, text_method: :name,
+              include_blank: "No category" %>
       </div>
 
       <div>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -57,11 +57,9 @@
             <div class="mt-3 space-y-4">
               <div>
                 <%= f.label :heading_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
-                <div class="mt-2">
-                  <%= f.select :heading_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                        data: { typography_preview_target: "headingFont", action: "typography-preview#update" } %>
-                </div>
+                <%= render "shared/custom_select", form: f, field: :heading_font,
+                      options: SiteSetting::Typography::GOOGLE_FONTS,
+                      data: { typography_preview_target: "headingFont", action: "typography-preview#update" } %>
               </div>
               <%= render "shared/range_slider", form: f, field: :heading_font_size, label: "Font size",
                     min: 0.75, max: 6, step: 0.125, suffix: "rem",
@@ -77,11 +75,9 @@
             <div class="mt-3 space-y-4">
               <div>
                 <%= f.label :subtitle_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
-                <div class="mt-2">
-                  <%= f.select :subtitle_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                        data: { typography_preview_target: "subtitleFont", action: "typography-preview#update" } %>
-                </div>
+                <%= render "shared/custom_select", form: f, field: :subtitle_font,
+                      options: SiteSetting::Typography::GOOGLE_FONTS,
+                      data: { typography_preview_target: "subtitleFont", action: "typography-preview#update" } %>
               </div>
               <%= render "shared/range_slider", form: f, field: :subtitle_font_size, label: "Font size",
                     min: 0.75, max: 6, step: 0.125, suffix: "rem",
@@ -97,11 +93,9 @@
             <div class="mt-3 space-y-4">
               <div>
                 <%= f.label :body_font, "Font family", class: "block text-sm font-medium text-gray-900" %>
-                <div class="mt-2">
-                  <%= f.select :body_font, SiteSetting::Typography::GOOGLE_FONTS, {},
-                        class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm",
-                        data: { typography_preview_target: "bodyFont", action: "typography-preview#update" } %>
-                </div>
+                <%= render "shared/custom_select", form: f, field: :body_font,
+                      options: SiteSetting::Typography::GOOGLE_FONTS,
+                      data: { typography_preview_target: "bodyFont", action: "typography-preview#update" } %>
               </div>
               <%= render "shared/range_slider", form: f, field: :body_font_size, label: "Font size",
                     min: 0.75, max: 6, step: 0.125, suffix: "rem",
@@ -166,18 +160,14 @@
 
         <div>
           <%= f.label :ai_model, "AI Model", class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.select :ai_model, SiteSetting::AiConfiguration::AI_MODELS.map { |m| [m, m] }, {},
-                  class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm" %>
-          </div>
+          <%= render "shared/custom_select", form: f, field: :ai_model,
+                options: SiteSetting::AiConfiguration::AI_MODELS.map { |m| [m, m] } %>
         </div>
 
         <div>
           <%= f.label :image_model, "Image Generation Model", class: "block text-sm font-medium text-gray-900" %>
-          <div class="mt-2">
-            <%= f.select :image_model, SiteSetting::AiConfiguration::IMAGE_MODELS.keys.map { |m| [m, m] }, {},
-                  class: "block w-full rounded-md bg-white px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm" %>
-          </div>
+          <%= render "shared/custom_select", form: f, field: :image_model,
+                options: SiteSetting::AiConfiguration::IMAGE_MODELS.keys.map { |m| [m, m] } %>
           <p class="mt-1 text-xs text-gray-500">Select which AI model to use for featured image generation.</p>
         </div>
 

--- a/app/views/shared/_custom_select.html.erb
+++ b/app/views/shared/_custom_select.html.erb
@@ -1,0 +1,34 @@
+<%# locals: (form:, field:, options: nil, collection: nil, value_method: nil, text_method: nil, include_blank: nil, data: {}) %>
+<%
+  extra_action = data.delete(:action)
+  merged_data = data.merge(custom_select_target: "select")
+  merged_data[:action] = extra_action if extra_action
+%>
+<div data-controller="custom-select" class="relative mt-2">
+  <div class="sr-only" aria-hidden="true">
+    <% if collection %>
+      <%= form.collection_select field, collection, value_method, text_method,
+            { include_blank: include_blank },
+            data: merged_data %>
+    <% else %>
+      <%= form.select field, options, { include_blank: include_blank }, data: merged_data %>
+    <% end %>
+  </div>
+
+  <button type="button"
+          data-custom-select-target="trigger"
+          data-action="click->custom-select#toggle"
+          class="relative w-full cursor-pointer rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
+    <span data-custom-select-target="triggerText" class="block truncate"></span>
+    <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+      <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+      </svg>
+    </span>
+  </button>
+
+  <ul data-custom-select-target="dropdown"
+      role="listbox"
+      class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 transition duration-100 ease-out hidden opacity-0 scale-95 focus:outline-none sm:text-sm">
+  </ul>
+</div>


### PR DESCRIPTION
## Summary
- Add a reusable custom select dropdown component (Stimulus controller + shared partial) that replaces native browser `<select>` elements with a polished UI: white trigger button with chevron, shadow dropdown, selected option highlighted in blue with a checkmark
- Full keyboard support: arrow keys, Enter/Space, Escape, Home/End, and type-ahead search
- Replace all 7 native selects across settings (3 typography fonts, 2 AI models) and post form (status, category)
- Typography live preview continues working via native `change` events dispatched on the hidden `<select>`

## Test plan
- [x] All 7 dropdowns show custom trigger with chevron icon
- [x] Clicking trigger opens dropdown with smooth transition
- [x] Selected option shows blue background + white checkmark
- [x] Clicking an option updates trigger text and closes dropdown
- [x] Outside click and Escape key close the dropdown
- [x] Keyboard navigation works (arrows, enter, type-ahead)
- [x] Typography font changes still update the live preview
- [x] Form submissions send correct values (settings save, post create/edit)
- [x] Category select shows "No category" blank option
- [x] Multiple dropdowns on same page don't interfere

🤖 Generated with [Claude Code](https://claude.com/claude-code)