### PR TITLE
Add X/Twitter post embedding in editor

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -274,6 +274,29 @@ trix-editor .attachment__caption,
   color: #6b7280;
 }
 
+/* -- X Post Embeds -------------------------------------------------------- */
+
+.lexxy-editor__content action-text-attachment:has(.x-post-embed),
+.trix-content action-text-attachment:has(.x-post-embed) {
+  display: block;
+  margin: 0.5em 0;
+}
+
+.x-post-embed {
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.x-post-embed .twitter-tweet,
+.x-post-embed .twitter-tweet-rendered {
+  margin: 0 !important;
+}
+
+.x-post-embed iframe {
+  margin: 0 !important;
+}
+
 /* -- First/Last child margin resets --------------------------------------- */
 
 .lexxy-editor__content > *:first-child,

--- a/app/controllers/admin/x_posts_controller.rb
+++ b/app/controllers/admin/x_posts_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class XPostsController < BaseController
+    def create
+      x_post = XPost.find_or_create_from_url(params[:url])
+
+      if x_post.persisted?
+        render json: {
+          sgid: x_post.attachable_sgid,
+          html: render_to_string(partial: "x_posts/x_post", locals: { x_post: x_post }, layout: false)
+        }
+      else
+        render json: { error: x_post.errors.full_messages.join(", ") }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/x_post_embed_controller.js
+++ b/app/javascript/controllers/x_post_embed_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+const X_POST_PATTERN = /^https?:\/\/(x\.com|twitter\.com)\/\w+\/status\/\d+/
+
+export default class extends Controller {
+  static values = { url: String }
+
+  connect() {
+    this.boundHandlePaste = this.handlePaste.bind(this)
+    this.element.addEventListener("paste", this.boundHandlePaste, true)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("paste", this.boundHandlePaste, true)
+  }
+
+  handlePaste(event) {
+    const text = event.clipboardData?.getData("text/plain")?.trim()
+    if (!text || !X_POST_PATTERN.test(text)) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const editor = this.element.querySelector("lexxy-editor")
+    if (!editor) return
+
+    fetch(this.urlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({ url: text })
+    })
+      .then(r => r.json())
+      .then(({ sgid, html }) => {
+        const attachment = document.createElement("action-text-attachment")
+        attachment.setAttribute("sgid", sgid)
+        attachment.setAttribute("content-type", "text/html")
+        attachment.setAttribute("content", JSON.stringify(html))
+        editor.contents.insertHtml(attachment.outerHTML)
+      })
+      .catch(err => console.error("[x-post-embed] error:", err))
+  }
+}

--- a/app/javascript/controllers/x_post_widget_controller.js
+++ b/app/javascript/controllers/x_post_widget_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    if (this.element.querySelector(".twitter-tweet")) {
+      this.loadAndRender()
+    }
+  }
+
+  loadAndRender() {
+    if (window.twttr?.widgets) {
+      window.twttr.widgets.load(this.element)
+    } else {
+      const script = document.createElement("script")
+      script.src = "https://platform.twitter.com/widgets.js"
+      script.onload = () => window.twttr.widgets.load(this.element)
+      document.head.appendChild(script)
+    }
+  }
+}

--- a/app/models/x_post.rb
+++ b/app/models/x_post.rb
@@ -1,0 +1,39 @@
+class XPost < ApplicationRecord
+  include ActionText::Attachable
+
+  validates :url, presence: true, uniqueness: true
+
+  def to_attachable_partial_path
+    "x_posts/x_post"
+  end
+
+  def to_trix_content_attachment_partial_path
+    "x_posts/x_post"
+  end
+
+  def self.find_or_create_from_url(url)
+    normalized = normalize_url(url)
+    find_or_create_by(url: normalized) do |x_post|
+      x_post.fetch_oembed!
+    end
+  end
+
+  def fetch_oembed!
+    uri = URI("https://publish.twitter.com/oembed?url=#{CGI.escape(url)}&omit_script=true")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.cert_store = OpenSSL::X509::Store.new.tap { |s| s.set_default_paths; s.flags = 0 }
+    response = http.get(uri.request_uri)
+    data = JSON.parse(response.body)
+    self.embed_html = data["html"]
+    self.author_name = data["author_name"]
+    self.author_username = data["author_url"]&.split("/")&.last
+  rescue StandardError => e
+    Rails.logger.warn("XPost oEmbed fetch failed for #{url}: #{e.message}")
+    self.embed_html = nil
+  end
+
+  def self.normalize_url(url)
+    url.gsub("twitter.com", "x.com").split("?").first
+  end
+end

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -24,7 +24,9 @@
 
     <hr class="border-gray-200">
 
-    <div class="editor-writing-area">
+    <div class="editor-writing-area"
+         data-controller="x-post-embed"
+         data-x-post-embed-url-value="<%= admin_x_posts_path %>">
       <%= f.rich_text_area :content, class: "min-h-[60vh] block w-full font-serif text-lg" %>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -30,7 +30,8 @@
     </div>
   <% end %>
 
-  <div class="prose prose-lg max-w-none prose-headings:font-display prose-a:text-ink-blue">
+  <div class="prose prose-lg max-w-none prose-headings:font-display prose-a:text-ink-blue"
+       data-controller="x-post-widget">
     <%= @post.content %>
   </div>
 

--- a/app/views/x_posts/_x_post.html.erb
+++ b/app/views/x_posts/_x_post.html.erb
@@ -1,0 +1,9 @@
+<div class="x-post-embed" data-controller="x-post-widget">
+  <% if x_post.embed_html.present? %>
+    <%= sanitize x_post.embed_html, tags: %w[blockquote a p br], attributes: %w[href class cite data-conversation] %>
+  <% else %>
+    <blockquote>
+      <a href="<%= x_post.url %>"><%= x_post.url %></a>
+    </blockquote>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         end
       end
     end
+    resources :x_posts, only: [ :create ]
     resources :categories
     resources :comments, only: [ :index, :update, :destroy ]
     resources :subscribers, only: [ :index, :show ]

--- a/db/migrate/20260219201804_create_x_posts.rb
+++ b/db/migrate/20260219201804_create_x_posts.rb
@@ -1,0 +1,14 @@
+class CreateXPosts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :x_posts do |t|
+      t.string :url, null: false
+      t.text :embed_html
+      t.string :author_name
+      t.string :author_username
+
+      t.timestamps
+    end
+
+    add_index :x_posts, :url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_015524) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_201804) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -265,6 +265,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_015524) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["identity_id"], name: "index_users_on_identity_id"
+  end
+
+  create_table "x_posts", force: :cascade do |t|
+    t.string "author_name"
+    t.string "author_username"
+    t.datetime "created_at", null: false
+    t.text "embed_html"
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.index ["url"], name: "index_x_posts_on_url", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## Summary
- Pasting an X (or Twitter) post URL in the Lexxy editor auto-converts it into an embedded tweet card using ActionText attachments
- New `XPost` model caches oEmbed data from Twitter's publish API, with URL normalization and deduplication
- Tweet embeds render both in the editor (via Stimulus paste interception) and on the public post page (via Twitter widgets.js)

## Test plan
- [x] Paste an X post URL (e.g. `https://x.com/rails/status/1880008302344192249`) in the editor — should render as an embedded tweet
- [x] Paste a `twitter.com` URL — should normalize to `x.com` and embed the same way
- [x] Paste a non-X URL — should insert as a normal link (no interception)
- [x] Save post and view publicly — tweet should render with full Twitter widget, centered
- [x] Paste the same URL again — should reuse existing XPost record (no duplicate)
- [x] `bin/rails test` passes (255 tests, 0 failures)
- [x] `bin/rubocop` clean (0 offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)