### PR TITLE
Add YouTube video embedding as ActionText attachments

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -297,6 +297,36 @@ trix-editor .attachment__caption,
   margin: 0 !important;
 }
 
+/* -- YouTube Video Embeds ------------------------------------------------- */
+
+.lexxy-editor__content action-text-attachment:has(.youtube-video-embed),
+.trix-content action-text-attachment:has(.youtube-video-embed) {
+  display: block;
+  margin: 1.5em 0;
+}
+
+.youtube-video-embed {
+  margin: 0 auto;
+  max-width: 100%;
+}
+
+.youtube-video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+.youtube-video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 /* -- First/Last child margin resets --------------------------------------- */
 
 .lexxy-editor__content > *:first-child,

--- a/app/controllers/admin/youtube_videos_controller.rb
+++ b/app/controllers/admin/youtube_videos_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class YouTubeVideosController < BaseController
+    def create
+      youtube_video = YouTubeVideo.find_or_create_from_url(params[:url])
+
+      if youtube_video&.persisted?
+        render json: {
+          sgid: youtube_video.attachable_sgid,
+          html: render_to_string(partial: "youtube_videos/youtube_video", locals: { youtube_video: youtube_video }, layout: false)
+        }
+      else
+        render json: { error: "Could not process YouTube URL" }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/youtube_embed_controller.js
+++ b/app/javascript/controllers/youtube_embed_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+const YOUTUBE_PATTERN = /^https?:\/\/(www\.)?(youtube\.com\/(watch\?v=|embed\/)|youtu\.be\/|m\.youtube\.com\/watch\?v=)[\w-]+/
+
+export default class extends Controller {
+  static values = { url: String }
+
+  connect() {
+    this.boundHandlePaste = this.handlePaste.bind(this)
+    this.element.addEventListener("paste", this.boundHandlePaste, true)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("paste", this.boundHandlePaste, true)
+  }
+
+  handlePaste(event) {
+    const text = event.clipboardData?.getData("text/plain")?.trim()
+    if (!text || !YOUTUBE_PATTERN.test(text)) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const editor = this.element.querySelector("lexxy-editor")
+    if (!editor) return
+
+    fetch(this.urlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({ url: text })
+    })
+      .then(r => r.json())
+      .then(({ sgid, html }) => {
+        const attachment = document.createElement("action-text-attachment")
+        attachment.setAttribute("sgid", sgid)
+        attachment.setAttribute("content-type", "text/html")
+        attachment.setAttribute("content", JSON.stringify(html))
+        editor.contents.insertHtml(attachment.outerHTML)
+      })
+      .catch(err => console.error("[youtube-embed] error:", err))
+  }
+}

--- a/app/models/youtube_video.rb
+++ b/app/models/youtube_video.rb
@@ -1,0 +1,73 @@
+class YouTubeVideo < ApplicationRecord
+  include ActionText::Attachable
+
+  validates :url, presence: true, uniqueness: true
+  validates :video_id, presence: true
+
+  def to_attachable_partial_path
+    "youtube_videos/youtube_video"
+  end
+
+  def to_trix_content_attachment_partial_path
+    "youtube_videos/youtube_video"
+  end
+
+  def self.find_or_create_from_url(url)
+    normalized = normalize_url(url)
+    vid = extract_video_id(normalized)
+    return nil unless vid
+
+    find_or_create_by(url: normalized) do |video|
+      video.video_id = vid
+      video.fetch_oembed!
+    end
+  end
+
+  def fetch_oembed!
+    uri = URI("https://www.youtube.com/oembed?url=#{CGI.escape(url)}&format=json")
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.cert_store = OpenSSL::X509::Store.new.tap { |s| s.set_default_paths; s.flags = 0 }
+    response = http.get(uri.request_uri)
+    data = JSON.parse(response.body)
+    self.title = data["title"]
+    self.author_name = data["author_name"]
+    self.thumbnail_url = data["thumbnail_url"]
+  rescue StandardError => e
+    Rails.logger.warn("YouTubeVideo oEmbed fetch failed for #{url}: #{e.message}")
+  end
+
+  def self.normalize_url(url)
+    url = url.strip
+    uri = URI.parse(url)
+    vid = extract_video_id_from_uri(uri)
+    vid ? "https://www.youtube.com/watch?v=#{vid}" : url
+  rescue URI::InvalidURIError
+    url
+  end
+
+  def self.extract_video_id(url)
+    uri = URI.parse(url)
+    extract_video_id_from_uri(uri)
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def self.extract_video_id_from_uri(uri)
+    host = uri.host&.downcase&.gsub(/\Awww\./, "")
+
+    case host
+    when "youtube.com", "m.youtube.com"
+      if uri.path == "/watch"
+        params = URI.decode_www_form(uri.query || "").to_h
+        params["v"]
+      elsif uri.path.start_with?("/embed/")
+        uri.path.split("/")[2]
+      end
+    when "youtu.be"
+      uri.path[1..]
+    end
+  end
+
+  private_class_method :extract_video_id_from_uri
+end

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -25,8 +25,9 @@
     <hr class="border-gray-200">
 
     <div class="editor-writing-area"
-         data-controller="x-post-embed"
-         data-x-post-embed-url-value="<%= admin_x_posts_path %>">
+         data-controller="x-post-embed youtube-embed"
+         data-x-post-embed-url-value="<%= admin_x_posts_path %>"
+         data-youtube-embed-url-value="<%= admin_youtube_videos_path %>">
       <%= f.rich_text_area :content, class: "min-h-[60vh] block w-full font-serif text-lg" %>
     </div>
   </div>

--- a/app/views/youtube_videos/_youtube_video.html.erb
+++ b/app/views/youtube_videos/_youtube_video.html.erb
@@ -1,0 +1,10 @@
+<div class="youtube-video-embed">
+  <div class="youtube-video-wrapper">
+    <iframe src="https://www.youtube.com/embed/<%= youtube_video.video_id %>"
+            title="<%= youtube_video.title || "YouTube video" %>"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+            loading="lazy">
+    </iframe>
+  </div>
+</div>

--- a/config/initializers/action_text.rb
+++ b/config/initializers/action_text.rb
@@ -1,0 +1,8 @@
+Rails.application.config.after_initialize do
+  ActionText::ContentHelper.allowed_tags = ActionText::ContentHelper.sanitizer.class.allowed_tags +
+    [ ActionText::Attachment.tag_name, "figure", "figcaption", "iframe" ]
+
+  ActionText::ContentHelper.allowed_attributes = ActionText::ContentHelper.sanitizer.class.allowed_attributes +
+    ActionText::Attachment::ATTRIBUTES +
+    %w[frameborder allowfullscreen allow loading]
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,4 +12,5 @@
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular "love", "loves"
+  inflect.acronym "YouTube"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       end
     end
     resources :x_posts, only: [ :create ]
+    resources :youtube_videos, only: [ :create ]
     resources :categories
     resources :comments, only: [ :index, :update, :destroy ]
     resources :subscribers, only: [ :index, :show ]

--- a/db/migrate/20260219222045_create_youtube_videos.rb
+++ b/db/migrate/20260219222045_create_youtube_videos.rb
@@ -1,0 +1,15 @@
+class CreateYoutubeVideos < ActiveRecord::Migration[8.1]
+  def change
+    create_table :youtube_videos do |t|
+      t.string :url, null: false
+      t.string :video_id, null: false
+      t.string :title
+      t.string :author_name
+      t.text :thumbnail_url
+
+      t.timestamps
+    end
+
+    add_index :youtube_videos, :url, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_201804) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_222045) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -275,6 +275,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_201804) do
     t.datetime "updated_at", null: false
     t.string "url", null: false
     t.index ["url"], name: "index_x_posts_on_url", unique: true
+  end
+
+  create_table "youtube_videos", force: :cascade do |t|
+    t.string "author_name"
+    t.datetime "created_at", null: false
+    t.text "thumbnail_url"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.string "video_id", null: false
+    t.index ["url"], name: "index_youtube_videos_on_url", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## Summary
- Paste a YouTube URL in the Lexxy editor and it auto-converts to a responsive 16:9 iframe embed
- Follows the same pattern as X/Twitter post embedding: `YouTubeVideo` model with `ActionText::Attachable`, admin controller, Stimulus paste handler, and rendering partial
- Supports all YouTube URL formats: `youtube.com/watch?v=`, `youtu.be/`, `youtube.com/embed/`, `m.youtube.com/watch?v=`
- Adds `iframe` to ActionText's sanitizer allowlist so embeds render on public pages
- Fetches oEmbed metadata (title, author, thumbnail) from YouTube's API

## Test plan
- [x] Paste `https://www.youtube.com/watch?v=dQw4w9WgXcQ` in editor → video embed appears
- [x] Paste `https://youtu.be/dQw4w9WgXcQ` → same behavior (normalized URL)
- [x] Save post, view publicly → responsive 16:9 YouTube player renders
- [x] Paste same URL again → reuses existing record (no duplicate)
- [x] Paste a non-YouTube URL → normal link behavior
- [x] Paste an X post URL → still works as before (no regression)
- [x] `bin/rails test` — 255 tests pass, 0 failures
- [x] `bin/rubocop` — 0 offenses
- [ ] `bin/brakeman` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)