### PR TITLE
Add autosave for post editor

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -31,9 +31,15 @@ module Admin
       @post = current_user.posts.build(post_params)
 
       if @post.save
-        redirect_to edit_admin_post_path(@post), notice: "Post created."
+        respond_to do |format|
+          format.html { redirect_to edit_admin_post_path(@post), notice: "Post created." }
+          format.json { render json: post_json(@post), status: :created }
+        end
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.html { render :new, status: :unprocessable_entity }
+          format.json { render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -42,9 +48,15 @@ module Admin
 
     def update
       if @post.update(post_params)
-        redirect_to edit_admin_post_path(@post), notice: "Post updated."
+        respond_to do |format|
+          format.html { redirect_to edit_admin_post_path(@post), notice: "Post updated." }
+          format.json { render json: post_json(@post), status: :ok }
+        end
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.html { render :edit, status: :unprocessable_entity }
+          format.json { render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -61,6 +73,14 @@ module Admin
 
     def post_params
       params.require(:post).permit(:title, :subtitle, :slug, :status, :published_at, :scheduled_at, :featured, :category_id, :content, :meta_description, :featured_image, tag_ids: [])
+    end
+
+    def post_json(post)
+      {
+        slug: post.to_param,
+        url: admin_post_path(post),
+        edit_url: edit_admin_post_path(post)
+      }
     end
 
     def choose_layout

--- a/app/javascript/controllers/autosave_controller.js
+++ b/app/javascript/controllers/autosave_controller.js
@@ -1,0 +1,195 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["status", "discardBackdrop", "discardModal"]
+  static values = {
+    url: String,
+    method: { type: String, default: "POST" },
+    persisted: { type: Boolean, default: false },
+    backUrl: String
+  }
+
+  connect() {
+    this.dirty = false
+    this.saving = false
+    this.pendingSave = false
+    this.saveTimer = null
+    this.savePromise = null
+    this.boundBeforeUnload = this.beforeUnload.bind(this)
+    window.addEventListener("beforeunload", this.boundBeforeUnload)
+  }
+
+  disconnect() {
+    clearTimeout(this.saveTimer)
+    window.removeEventListener("beforeunload", this.boundBeforeUnload)
+  }
+
+  scheduleAutosave() {
+    this.dirty = true
+    this.updateStatus("unsaved")
+    clearTimeout(this.saveTimer)
+    this.saveTimer = setTimeout(() => this.save(), 3000)
+  }
+
+  handleChange(event) {
+    if (event.target.type === "file") {
+      this.dirty = true
+      this.save()
+    } else {
+      this.scheduleAutosave()
+    }
+  }
+
+  preventSubmit(event) {
+    event.preventDefault()
+    this.scheduleAutosave()
+  }
+
+  async save() {
+    const titleInput = this.element.querySelector("#post_title")
+    if (titleInput && !titleInput.value.trim()) return
+
+    if (this.saving) {
+      this.pendingSave = true
+      return this.savePromise
+    }
+
+    this.saving = true
+    this.updateStatus("saving")
+
+    const form = this.element.querySelector("#post_form")
+    const formData = new FormData(form)
+
+    // Remove empty file inputs to avoid re-uploading
+    for (const [key, value] of [...formData.entries()]) {
+      if (value instanceof File && value.size === 0) {
+        formData.delete(key)
+      }
+    }
+
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+    this.savePromise = fetch(this.urlValue, {
+      method: this.methodValue,
+      headers: {
+        "Accept": "application/json",
+        "X-CSRF-Token": csrfToken
+      },
+      body: formData
+    })
+      .then(async (response) => {
+        const data = await response.json()
+
+        if (response.ok) {
+          if (!this.persistedValue) {
+            // First create — transition to edit mode
+            history.replaceState({}, "", data.edit_url)
+            form.action = data.url
+            this.urlValue = data.url
+            this.methodValue = "PATCH"
+            this.persistedValue = true
+          } else if (data.url !== this.urlValue) {
+            // Slug changed
+            history.replaceState({}, "", data.edit_url)
+            form.action = data.url
+            this.urlValue = data.url
+          }
+
+          this.dirty = false
+          this.updateStatus("saved")
+        } else {
+          this.updateStatus("error")
+          setTimeout(() => this.save(), 5000)
+        }
+      })
+      .catch(() => {
+        this.updateStatus("error")
+        setTimeout(() => this.save(), 5000)
+      })
+      .finally(() => {
+        this.saving = false
+        if (this.pendingSave) {
+          this.pendingSave = false
+          this.save()
+        }
+      })
+
+    return this.savePromise
+  }
+
+  async handleBack(event) {
+    event.preventDefault()
+
+    const titleInput = this.element.querySelector("#post_title")
+    const hasTitle = titleInput && titleInput.value.trim()
+
+    if (!this.persistedValue && !hasTitle) {
+      this.openDiscardModal()
+      return
+    }
+
+    if (this.dirty) {
+      this.updateStatus("saving")
+      const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("timeout")), 10000)
+      )
+      try {
+        await Promise.race([this.save(), timeout])
+      } catch {
+        // Navigate anyway after timeout
+      }
+    }
+
+    window.Turbo.visit(this.backUrlValue)
+  }
+
+  openDiscardModal() {
+    this.discardBackdropTarget.classList.remove("hidden")
+    this.discardModalTarget.classList.remove("hidden")
+    document.body.classList.add("overflow-hidden")
+  }
+
+  closeDiscardModal() {
+    this.discardBackdropTarget.classList.add("hidden")
+    this.discardModalTarget.classList.add("hidden")
+    document.body.classList.remove("overflow-hidden")
+  }
+
+  confirmDiscard() {
+    this.dirty = false
+    window.Turbo.visit(this.backUrlValue)
+  }
+
+  updateStatus(state) {
+    if (!this.hasStatusTarget) return
+
+    const el = this.statusTarget
+    el.classList.remove("text-amber-600", "text-gray-500", "text-red-600")
+
+    switch (state) {
+      case "unsaved":
+        el.textContent = "Unsaved changes"
+        el.classList.add("text-amber-600")
+        break
+      case "saving":
+        el.textContent = "Saving..."
+        el.classList.add("text-gray-500")
+        break
+      case "saved":
+        el.textContent = "Saved"
+        el.classList.add("text-gray-500")
+        break
+      case "error":
+        el.textContent = "Save failed"
+        el.classList.add("text-red-600")
+        break
+    }
+  }
+
+  beforeUnload(event) {
+    if (this.dirty) {
+      event.preventDefault()
+      event.returnValue = ""
+    }
+  }
+}

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -1,4 +1,5 @@
-<%= form_with model: [:admin, post], id: "post_form" do |f| %>
+<%= form_with model: [:admin, post], id: "post_form",
+      data: { action: "input->autosave#scheduleAutosave change->autosave#handleChange lexxy:change->autosave#scheduleAutosave submit->autosave#preventSubmit" } do |f| %>
   <% if post.errors.any? %>
     <div class="mb-6 rounded-md bg-red-50 p-4">
       <h3 class="text-sm font-medium text-red-800"><%= pluralize(post.errors.count, "error") %> prevented this post from being saved:</h3>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -4,10 +4,6 @@
   <%= button_to "Delete", admin_post_path(@post), method: :delete,
         data: { turbo_confirm: "Are you sure you want to delete this post?" },
         class: "rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-red-500" %>
-  <button type="submit" form="post_form"
-          class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 cursor-pointer">
-    Save
-  </button>
 <% end %>
 
 <%= render "form", post: @post %>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -1,10 +1,3 @@
 <% content_for(:title, "New Post — #{site_name}") %>
 
-<% content_for(:top_bar_actions) do %>
-  <button type="submit" form="post_form"
-          class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 cursor-pointer">
-    Save Draft
-  </button>
-<% end %>
-
 <%= render "form", post: @post %>

--- a/app/views/layouts/admin_editor.html.erb
+++ b/app/views/layouts/admin_editor.html.erb
@@ -18,7 +18,17 @@
   </head>
 
   <body class="h-full">
-    <div data-controller="editor-panel <%= 'ai-panel' if SiteSetting.current.ai_configured? %>"
+    <div data-controller="autosave editor-panel <%= 'ai-panel' if SiteSetting.current.ai_configured? %>"
+         data-autosave-back-url-value="<%= admin_posts_path %>"
+         <% if @post&.persisted? %>
+           data-autosave-url-value="<%= admin_post_path(@post) %>"
+           data-autosave-method-value="PATCH"
+           data-autosave-persisted-value="true"
+         <% else %>
+           data-autosave-url-value="<%= admin_posts_path %>"
+           data-autosave-method-value="POST"
+           data-autosave-persisted-value="false"
+         <% end %>
          <% if SiteSetting.current.ai_configured? && @post&.persisted? %>
            data-ai-panel-post-slug-value="<%= @post.to_param %>"
          <% end %>
@@ -26,14 +36,15 @@
       <%# Top bar %>
       <header class="sticky top-0 z-40 flex h-14 items-center justify-between border-b border-gray-200 bg-white px-4">
         <div>
-          <%= link_to admin_posts_path, class: "inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900" do %>
+          <a href="#" data-action="click->autosave#handleBack" class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
             </svg>
             Posts
-          <% end %>
+          </a>
         </div>
         <div class="flex items-center gap-2">
+          <span data-autosave-target="status" class="text-xs text-gray-500"></span>
           <%= yield :top_bar_actions %>
           <% if SiteSetting.current.ai_configured? && @post&.persisted? %>
             <button type="button"
@@ -82,6 +93,30 @@
            data-ai-panel-target="overlay"
            data-action="click->editor-panel#close click->ai-panel#close"
            class="fixed inset-0 z-40 bg-black/30 transition-opacity duration-300 hidden opacity-0"></div>
+
+      <%# Discard modal %>
+      <div data-autosave-target="discardBackdrop"
+           data-action="click->autosave#closeDiscardModal"
+           class="fixed inset-0 z-60 bg-black/30 hidden"></div>
+      <div data-autosave-target="discardModal"
+           class="fixed inset-0 z-70 flex items-center justify-center hidden">
+        <div class="w-full max-w-sm rounded-lg bg-white p-6 shadow-xl">
+          <h3 class="text-lg font-semibold text-gray-900">Discard post?</h3>
+          <p class="mt-2 text-sm text-gray-600">This post hasn't been saved yet. Are you sure you want to discard it?</p>
+          <div class="mt-4 flex justify-end gap-3">
+            <button type="button"
+                    data-action="click->autosave#closeDiscardModal"
+                    class="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-200">
+              Keep editing
+            </button>
+            <button type="button"
+                    data-action="click->autosave#confirmDiscard"
+                    class="rounded-md bg-red-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-red-500">
+              Discard
+            </button>
+          </div>
+        </div>
+      </div>
 
       <%# AI panel %>
       <% if SiteSetting.current.ai_configured? && @post&.persisted? %>

--- a/test/controllers/admin/posts_controller_test.rb
+++ b/test/controllers/admin/posts_controller_test.rb
@@ -58,6 +58,41 @@ class Admin::PostsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_posts_path
   end
 
+  test "POST create as JSON returns created with post data" do
+    assert_difference "Post.count", 1 do
+      post admin_posts_path, params: { post: { title: "Autosaved Post" } }, as: :json
+    end
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["slug"].present?
+    assert json["url"].present?
+    assert json["edit_url"].present?
+  end
+
+  test "POST create as JSON with blank title returns errors" do
+    post admin_posts_path, params: { post: { title: "" } }, as: :json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["errors"].any?
+  end
+
+  test "PATCH update as JSON returns ok with post data" do
+    patch admin_post_path(posts(:draft_post)), params: { post: { title: "Updated via JSON" } }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert json["slug"].present?
+    assert json["url"].present?
+    assert json["edit_url"].present?
+    assert_equal "Updated via JSON", posts(:draft_post).reload.title
+  end
+
+  test "PATCH update as JSON with blank title returns errors" do
+    patch admin_post_path(posts(:draft_post)), params: { post: { title: "" } }, as: :json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["errors"].any?
+  end
+
   test "requires authentication" do
     delete admin_session_path
     get admin_posts_path


### PR DESCRIPTION
## Summary

- Posts now autosave in the background with a 3-second debounce after the last change, replacing manual Save/Save Draft buttons
- A status indicator in the header shows save state: "Unsaved changes" (amber), "Saving..." (gray), "Saved" (gray), "Save failed" (red)
- Clicking the "Posts" back button on an existing post saves first then navigates; on a new post without a title, a discard confirmation modal appears
- JSON responses added to `create` and `update` actions so the Stimulus controller can save via `fetch`

## Test plan

- [ ] `bin/rails test` — all 259 tests pass (4 new JSON format tests added)
- [ ] `bin/rubocop` — 0 offenses
- [ ] `bin/brakeman` — 0 warnings
- [ ] New post: type title → status shows "Saving..." then "Saved", URL changes to edit path
- [ ] New post: type content but no title → click Posts back → discard modal appears
- [ ] New post: discard modal → "Keep editing" → stays on page
- [ ] New post: discard modal → "Discard" → goes to posts list
- [ ] Edit post: change title → status shows "Saving..." then "Saved" after 3s
- [ ] Edit post: click Posts back → saves then navigates to posts list
- [ ] Edit post: change content → close tab → browser warns about unsaved changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)