### PR TITLE
Replace tag checkboxes with searchable combo box

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -1,0 +1,19 @@
+module Admin
+  class TagsController < BaseController
+    def create
+      tag = Tag.find_or_initialize_by(name: tag_params[:name].strip)
+
+      if tag.save
+        render json: { id: tag.id, name: tag.name, slug: tag.slug }
+      else
+        render json: { errors: tag.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def tag_params
+      params.require(:tag).permit(:name)
+    end
+  end
+end

--- a/app/javascript/controllers/editor_drawer_controller.js
+++ b/app/javascript/controllers/editor_drawer_controller.js
@@ -294,10 +294,11 @@ export default class extends Controller {
       return
     }
 
-    // Escape to close (skip if a custom-select dropdown is open)
+    // Escape to close (skip if a custom-select or tag-select dropdown is open)
     if (event.key === "Escape" && this.isOpen) {
       const openDropdown = document.querySelector("[data-custom-select-target='dropdown']:not(.hidden)")
-      if (openDropdown) return
+      const openTagSelect = document.querySelector("[data-tag-select-target='dropdown']:not(.hidden)")
+      if (openDropdown || openTagSelect) return
       this.close()
     }
   }

--- a/app/javascript/controllers/tag_select_controller.js
+++ b/app/javascript/controllers/tag_select_controller.js
@@ -1,0 +1,313 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "emptyInput", "hiddenInputs", "comboBox", "pills",
+    "searchInput", "dropdown", "option", "createOption", "createLabel"
+  ]
+
+  static values = {
+    createUrl: String,
+    formAttr: String,
+    fieldName: String
+  }
+
+  connect() {
+    this.boundClickOutside = this.clickOutside.bind(this)
+    document.addEventListener("click", this.boundClickOutside)
+    this.highlightedIndex = -1
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundClickOutside)
+  }
+
+  // --- Open / Close ---
+
+  open() {
+    this.dropdownTarget.classList.remove("hidden")
+    this.highlightedIndex = -1
+    this.clearHighlight()
+  }
+
+  close() {
+    this.dropdownTarget.classList.add("hidden")
+    this.searchInputTarget.value = ""
+    this.filter()
+    this.highlightedIndex = -1
+    this.clearHighlight()
+  }
+
+  clickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.close()
+    }
+  }
+
+  focusInput() {
+    this.searchInputTarget.focus()
+  }
+
+  // --- Filter ---
+
+  filter() {
+    const query = this.searchInputTarget.value.trim().toLowerCase()
+    let hasExactMatch = false
+    let visibleCount = 0
+
+    this.optionTargets.forEach(option => {
+      const name = option.dataset.tagName
+      if (!query || name.includes(query)) {
+        option.classList.remove("hidden")
+        visibleCount++
+      } else {
+        option.classList.add("hidden")
+      }
+      if (name === query) hasExactMatch = true
+    })
+
+    if (this.hasCreateOptionTarget) {
+      if (query && !hasExactMatch && this.hasCreateUrlValue) {
+        this.createOptionTarget.classList.remove("hidden")
+        this.createLabelTarget.textContent = this.searchInputTarget.value.trim()
+      } else {
+        this.createOptionTarget.classList.add("hidden")
+      }
+    }
+
+    this.highlightedIndex = -1
+    this.clearHighlight()
+  }
+
+  // --- Selection ---
+
+  toggleTag(event) {
+    const li = event.currentTarget
+    const id = li.dataset.tagId
+    const name = li.querySelector("span").textContent.trim()
+
+    if (this.isSelected(id)) {
+      this.removeTagById(id)
+    } else {
+      this.selectTag(id, name)
+    }
+  }
+
+  selectTag(id, name) {
+    if (this.isSelected(id)) return
+
+    // Add hidden input
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = this.fieldNameValue
+    input.value = id
+    if (this.formAttrValue) input.setAttribute("form", this.formAttrValue)
+    input.dataset.tagId = id
+    this.hiddenInputsTarget.appendChild(input)
+
+    // Add pill
+    const pill = document.createElement("span")
+    pill.className = "inline-flex items-center gap-1 rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700"
+    pill.dataset.tagId = id
+    pill.innerHTML = `${this.escapeHtml(name)}<button type="button" data-action="click->tag-select#removeTag" data-tag-id="${id}" class="ml-0.5 inline-flex items-center rounded-full hover:bg-blue-200 focus:outline-none" tabindex="-1"><svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg></button>`
+    this.pillsTarget.appendChild(pill)
+
+    // Update option style
+    this.markOptionSelected(id, true)
+
+    this.searchInputTarget.value = ""
+    this.filter()
+    this.dispatchChange()
+  }
+
+  removeTag(event) {
+    event.stopPropagation()
+    const id = event.currentTarget.dataset.tagId
+    this.removeTagById(id)
+  }
+
+  removeTagById(id) {
+    // Remove hidden input
+    const input = this.hiddenInputsTarget.querySelector(`input[data-tag-id="${id}"]`)
+    if (input) input.remove()
+
+    // Remove pill
+    const pill = this.pillsTarget.querySelector(`[data-tag-id="${id}"]`)
+    if (pill) pill.remove()
+
+    // Update option style
+    this.markOptionSelected(id, false)
+
+    this.dispatchChange()
+  }
+
+  // --- Create ---
+
+  async createTag() {
+    const name = this.searchInputTarget.value.trim()
+    if (!name || !this.hasCreateUrlValue) return
+
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+    try {
+      const response = await fetch(this.createUrlValue, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+          "Accept": "application/json"
+        },
+        body: JSON.stringify({ tag: { name } })
+      })
+
+      if (!response.ok) return
+
+      const data = await response.json()
+
+      // Insert new option alphabetically if it doesn't already exist
+      if (!this.optionTargets.find(o => o.dataset.tagId === String(data.id))) {
+        const li = document.createElement("li")
+        li.dataset.tagSelectTarget = "option"
+        li.dataset.tagId = data.id
+        li.dataset.tagName = data.name.toLowerCase()
+        li.dataset.action = "click->tag-select#toggleTag"
+        li.setAttribute("role", "option")
+        li.className = "relative cursor-pointer select-none py-2 pl-3 pr-9 text-gray-900 hover:bg-gray-100"
+        li.innerHTML = `<span class="block truncate">${this.escapeHtml(data.name)}</span>`
+
+        // Find insertion point (alphabetical by name)
+        const insertBefore = this.optionTargets.find(o =>
+          o.dataset.tagName > data.name.toLowerCase()
+        )
+        if (insertBefore) {
+          this.dropdownTarget.insertBefore(li, insertBefore)
+        } else {
+          // Insert before the create option
+          this.dropdownTarget.insertBefore(li, this.createOptionTarget)
+        }
+      }
+
+      this.selectTag(String(data.id), data.name)
+    } catch (e) {
+      // Silently fail — user can retry
+    }
+  }
+
+  // --- Keyboard Navigation ---
+
+  handleKeydown(event) {
+    const visibleOptions = this.visibleOptions()
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault()
+        if (!this.isOpen) { this.open(); return }
+        this.highlightedIndex = Math.min(this.highlightedIndex + 1, visibleOptions.length - 1)
+        this.updateHighlight(visibleOptions)
+        break
+
+      case "ArrowUp":
+        event.preventDefault()
+        this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0)
+        this.updateHighlight(visibleOptions)
+        break
+
+      case "Enter":
+        event.preventDefault()
+        if (this.highlightedIndex >= 0 && visibleOptions[this.highlightedIndex]) {
+          visibleOptions[this.highlightedIndex].click()
+        } else if (!this.createOptionTarget.classList.contains("hidden")) {
+          this.createTag()
+        }
+        break
+
+      case "Escape":
+        event.stopPropagation()
+        this.close()
+        this.searchInputTarget.blur()
+        break
+
+      case "Backspace":
+        if (this.searchInputTarget.value === "") {
+          const pills = this.pillsTarget.querySelectorAll("[data-tag-id]")
+          if (pills.length > 0) {
+            const lastPill = pills[pills.length - 1]
+            this.removeTagById(lastPill.dataset.tagId)
+          }
+        }
+        break
+    }
+  }
+
+  // --- Helpers ---
+
+  get isOpen() {
+    return !this.dropdownTarget.classList.contains("hidden")
+  }
+
+  isSelected(id) {
+    return !!this.hiddenInputsTarget.querySelector(`input[data-tag-id="${id}"]`)
+  }
+
+  markOptionSelected(id, selected) {
+    const option = this.optionTargets.find(o => o.dataset.tagId === String(id))
+    if (!option) return
+
+    if (selected) {
+      option.classList.add("bg-blue-600", "text-white", "hover:bg-blue-700")
+      option.classList.remove("text-gray-900", "hover:bg-gray-100")
+      // Add checkmark
+      let check = option.querySelector(".checkmark")
+      if (!check) {
+        const span = document.createElement("span")
+        span.className = "checkmark absolute inset-y-0 right-0 flex items-center pr-3 text-white"
+        span.innerHTML = '<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>'
+        option.appendChild(span)
+      }
+    } else {
+      option.classList.remove("bg-blue-600", "text-white", "hover:bg-blue-700")
+      option.classList.add("text-gray-900", "hover:bg-gray-100")
+      const check = option.querySelector(".checkmark")
+      if (check) check.remove()
+    }
+  }
+
+  visibleOptions() {
+    const options = []
+    this.optionTargets.forEach(o => {
+      if (!o.classList.contains("hidden")) options.push(o)
+    })
+    if (!this.createOptionTarget.classList.contains("hidden")) {
+      options.push(this.createOptionTarget)
+    }
+    return options
+  }
+
+  clearHighlight() {
+    this.optionTargets.forEach(o => o.classList.remove("bg-gray-100"))
+    if (this.hasCreateOptionTarget) this.createOptionTarget.classList.remove("bg-blue-50")
+  }
+
+  updateHighlight(visibleOptions) {
+    this.clearHighlight()
+    const target = visibleOptions[this.highlightedIndex]
+    if (!target) return
+
+    if (target === this.createOptionTarget) {
+      target.classList.add("bg-blue-50")
+    } else if (!target.classList.contains("bg-blue-600")) {
+      target.classList.add("bg-gray-100")
+    }
+    target.scrollIntoView({ block: "nearest" })
+  }
+
+  dispatchChange() {
+    this.hiddenInputsTarget.dispatchEvent(new Event("change", { bubbles: true }))
+  }
+
+  escapeHtml(str) {
+    const div = document.createElement("div")
+    div.textContent = str
+    return div.innerHTML
+  }
+}

--- a/app/views/admin/posts/_editor_panel.html.erb
+++ b/app/views/admin/posts/_editor_panel.html.erb
@@ -110,7 +110,9 @@
   <% end %>
 
   <%# Settings tab content %>
-  <div data-editor-drawer-target="tabContent" data-tab="settings" class="hidden flex-1 overflow-y-auto">
+  <div data-editor-drawer-target="tabContent" data-tab="settings"
+       data-action="change->autosave#handleChange input->autosave#scheduleAutosave"
+       class="hidden flex-1 overflow-y-auto">
     <%= render "admin/posts/settings_fields", post: post %>
   </div>
 </div>

--- a/app/views/admin/posts/_settings_fields.html.erb
+++ b/app/views/admin/posts/_settings_fields.html.erb
@@ -39,15 +39,13 @@
 
     <div>
       <%= f.label :tag_ids, "Tags", class: "block text-sm font-medium text-gray-900" %>
-      <div class="mt-2">
-        <input type="hidden" name="post[tag_ids][]" value="" form="post_form">
-        <%= f.collection_check_boxes :tag_ids, Tag.all.order(:name), :id, :name do |b| %>
-          <label class="flex items-center space-x-2 py-1">
-            <%= b.check_box class: "rounded border-gray-300 text-gray-600 focus:ring-gray-600", form: "post_form" %>
-            <span class="text-sm text-gray-700"><%= b.text %></span>
-          </label>
-        <% end %>
-      </div>
+      <%= render "shared/tag_select",
+            form: f,
+            field: :tag_ids,
+            tags: Tag.all.order(:name),
+            selected_ids: post.tag_ids,
+            form_attr: "post_form",
+            create_url: admin_tags_path %>
     </div>
 
     <div class="flex items-center">

--- a/app/views/shared/_tag_select.html.erb
+++ b/app/views/shared/_tag_select.html.erb
@@ -1,0 +1,74 @@
+<%# locals: (form:, field:, tags:, selected_ids:, form_attr: nil, create_url: nil) %>
+<%
+  field_name = "#{form.object_name}[#{field}][]"
+  selected_set = selected_ids.to_set
+%>
+<div data-controller="tag-select"
+     data-tag-select-create-url-value="<%= create_url %>"
+     data-tag-select-form-attr-value="<%= form_attr %>"
+     data-tag-select-field-name-value="<%= field_name %>"
+     class="relative mt-2">
+
+  <%# Empty sentinel so tag_ids is always submitted (clears all tags when none selected) %>
+  <input type="hidden" name="<%= field_name %>" value="" form="<%= form_attr %>" data-tag-select-target="emptyInput">
+
+  <%# Container for hidden inputs (one per selected tag) %>
+  <div data-tag-select-target="hiddenInputs">
+    <% tags.select { |t| selected_set.include?(t.id) }.each do |tag| %>
+      <input type="hidden" name="<%= field_name %>" value="<%= tag.id %>" form="<%= form_attr %>" data-tag-id="<%= tag.id %>">
+    <% end %>
+  </div>
+
+  <%# Combo box: pills + search input %>
+  <div data-tag-select-target="comboBox"
+       data-action="click->tag-select#focusInput"
+       class="flex flex-wrap items-center gap-1 rounded-md bg-white px-2 py-1.5 shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-blue-500 cursor-text min-h-[38px]">
+    <div data-tag-select-target="pills" class="contents">
+      <% tags.select { |t| selected_set.include?(t.id) }.each do |tag| %>
+        <span class="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700" data-tag-id="<%= tag.id %>">
+          <%= tag.name %>
+          <button type="button" data-action="click->tag-select#removeTag" data-tag-id="<%= tag.id %>" class="ml-0.5 inline-flex items-center rounded-full hover:bg-blue-200 focus:outline-none" tabindex="-1">
+            <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+          </button>
+        </span>
+      <% end %>
+    </div>
+    <input type="text"
+           data-tag-select-target="searchInput"
+           data-action="input->tag-select#filter focus->tag-select#open keydown->tag-select#handleKeydown"
+           class="flex-1 min-w-[80px] border-0 bg-transparent p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:ring-0 focus:outline-none"
+           placeholder="Search or create tags..."
+           autocomplete="off">
+  </div>
+
+  <%# Dropdown %>
+  <ul data-tag-select-target="dropdown"
+      role="listbox"
+      class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 hidden focus:outline-none sm:text-sm">
+    <% tags.each do |tag| %>
+      <li data-tag-select-target="option"
+          data-tag-id="<%= tag.id %>"
+          data-tag-name="<%= tag.name.downcase %>"
+          data-action="click->tag-select#toggleTag"
+          role="option"
+          class="relative cursor-pointer select-none py-2 pl-3 pr-9 text-gray-900 hover:bg-gray-100 <%= 'bg-blue-600 text-white hover:bg-blue-700' if selected_set.include?(tag.id) %>">
+        <span class="block truncate"><%= tag.name %></span>
+        <% if selected_set.include?(tag.id) %>
+          <span class="absolute inset-y-0 right-0 flex items-center pr-3 text-white">
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+            </svg>
+          </span>
+        <% end %>
+      </li>
+    <% end %>
+    <li data-tag-select-target="createOption"
+        data-action="click->tag-select#createTag"
+        role="option"
+        class="relative cursor-pointer select-none py-2 pl-3 pr-9 text-blue-600 hover:bg-blue-50 hidden">
+      <span class="block truncate">Create "<span data-tag-select-target="createLabel"></span>"</span>
+    </li>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     end
     resources :x_posts, only: [ :create ]
     resources :youtube_videos, only: [ :create ]
+    resources :tags, only: [ :create ]
     resources :categories
     resources :comments, only: [ :index, :update, :destroy ]
     resources :subscribers, only: [ :index, :show ]

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as(:admin)
+  end
+
+  test "POST create creates a new tag and returns JSON" do
+    assert_difference "Tag.count", 1 do
+      post admin_tags_path, params: { tag: { name: "JavaScript" } }, as: :json
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "JavaScript", json["name"]
+    assert_equal "javascript", json["slug"]
+    assert json["id"].present?
+  end
+
+  test "POST create returns existing tag when name matches" do
+    existing = tags(:ruby)
+
+    assert_no_difference "Tag.count" do
+      post admin_tags_path, params: { tag: { name: "Ruby" } }, as: :json
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal existing.id, json["id"]
+    assert_equal "Ruby", json["name"]
+  end
+
+  test "POST create strips whitespace from name" do
+    assert_difference "Tag.count", 1 do
+      post admin_tags_path, params: { tag: { name: "  Elixir  " } }, as: :json
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "Elixir", json["name"]
+    assert_equal "elixir", json["slug"]
+  end
+
+  test "POST create returns 422 for blank name" do
+    assert_no_difference "Tag.count" do
+      post admin_tags_path, params: { tag: { name: "  " } }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["errors"].any? { |e| e.include?("Name") }
+  end
+
+  test "POST create requires authentication" do
+    delete admin_session_path
+
+    post admin_tags_path, params: { tag: { name: "Go" } }, as: :json
+
+    assert_response :redirect
+  end
+end


### PR DESCRIPTION
## Summary
- Replace the vertical checkbox list for tags with a searchable combo box featuring removable blue pills, type-ahead filtering, keyboard navigation (arrow keys, Enter, Escape, Backspace), and inline tag creation
- Add `POST /admin/tags` endpoint for creating tags from the combo box (idempotent — returns existing tag if name matches)
- Fix settings panel autosave: fields outside the `<form>` element were not triggering autosave because their DOM events bubble through the editor panel, not through the form — added `change`/`input` listeners on the settings tab container

## Test plan
- [x] `bin/rails test` — 264 tests, 0 failures
- [x] `bin/rubocop` — 0 offenses
- [x] `bin/brakeman` — 0 warnings
- [x] Manual: Open editor Settings tab → Tags section shows combo box (not checkboxes)
- [x] Manual: Type to filter, create new tags, select/deselect with clicks and keyboard
- [x] Manual: Escape closes dropdown without closing editor panel
- [x] Manual: Autosave fires after tag and other settings changes (check network tab for PATCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)