### PR TITLE
Add inline post preview to the admin editor

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class PostsController < BaseController
     layout :choose_layout
 
-    before_action :set_post, only: [ :edit, :update, :destroy ]
+    before_action :set_post, only: [ :edit, :update, :destroy, :preview ]
 
     def index
       @posts = Post.includes(:user, :category)
@@ -58,6 +58,11 @@ module Admin
           format.json { render json: { errors: @post.errors.full_messages }, status: :unprocessable_entity }
         end
       end
+    end
+
+    def preview
+      @post = Post.includes(:user, :category, :tags).find_by!(slug: params[:id])
+      render partial: "preview", locals: { post: @post }, layout: false
     end
 
     def destroy

--- a/app/javascript/controllers/post_preview_controller.js
+++ b/app/javascript/controllers/post_preview_controller.js
@@ -1,0 +1,111 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["editor", "preview", "toggleButton", "toggleIcon", "toggleLabel"]
+
+  connect() {
+    this.previewing = false
+    this.boundKeydown = this.handleKeydown.bind(this)
+    document.addEventListener("keydown", this.boundKeydown)
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.boundKeydown)
+  }
+
+  handleKeydown(event) {
+    if (!this.hasEditorTarget) return
+
+    if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key === "p") {
+      event.preventDefault()
+      this.toggle()
+    }
+  }
+
+  async toggle() {
+    if (!this.hasEditorTarget) return
+
+    if (this.previewing) {
+      this.showEditor()
+    } else {
+      await this.showPreview()
+    }
+  }
+
+  async showPreview() {
+    const autosave = this.application.getControllerForElementAndIdentifier(this.element, "autosave")
+
+    if (autosave) {
+      if (autosave.dirty || autosave.saving) {
+        try {
+          if (autosave.saving) {
+            await autosave.savePromise
+          }
+          if (autosave.dirty) {
+            await autosave.save()
+          }
+        } catch {
+          return
+        }
+      }
+
+      if (!autosave.persistedValue) return
+    }
+
+    const previewUrl = this.#buildPreviewUrl(autosave)
+    if (!previewUrl) return
+
+    try {
+      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+      const response = await fetch(previewUrl, {
+        headers: {
+          "Accept": "text/html",
+          "X-CSRF-Token": csrfToken
+        }
+      })
+
+      if (!response.ok) return
+
+      const html = await response.text()
+      this.previewTarget.innerHTML = html
+      this.editorTarget.classList.add("hidden")
+      this.previewTarget.classList.remove("hidden")
+      this.previewing = true
+      this.updateButton()
+    } catch {
+      // Silently fail — editor remains visible
+    }
+  }
+
+  showEditor() {
+    this.previewTarget.classList.add("hidden")
+    this.previewTarget.innerHTML = ""
+    this.editorTarget.classList.remove("hidden")
+    this.previewing = false
+    this.updateButton()
+  }
+
+  updateButton() {
+    if (!this.hasToggleLabelTarget) return
+
+    if (this.previewing) {
+      this.toggleLabelTarget.textContent = "Edit"
+      this.toggleIconTarget.innerHTML = `
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+      `
+    } else {
+      this.toggleLabelTarget.textContent = "Preview"
+      this.toggleIconTarget.innerHTML = `
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+      `
+    }
+  }
+
+  #buildPreviewUrl(autosave) {
+    if (!autosave) return null
+    const baseUrl = autosave.urlValue
+    if (!baseUrl) return null
+    return `${baseUrl}/preview`
+  }
+}

--- a/app/views/admin/posts/_preview.html.erb
+++ b/app/views/admin/posts/_preview.html.erb
@@ -1,0 +1,52 @@
+<div class="bg-cream text-charcoal font-serif -mx-4 -mt-8 px-4 py-8 min-h-[80vh]">
+  <div class="mx-auto max-w-3xl">
+    <div class="mb-6">
+      <span class="inline-block rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800 font-sans">Preview</span>
+    </div>
+
+    <article>
+      <header class="mb-8 border-b border-gray-300 pb-8">
+        <h1 class="font-display text-4xl font-bold leading-tight lg:text-5xl"><%= post.title %></h1>
+        <% if post.subtitle.present? %>
+          <p class="mt-3 text-xl text-gray-600 font-subtitle"><%= post.subtitle %></p>
+        <% end %>
+        <div class="mt-4 flex flex-wrap items-center gap-3 text-sm text-gray-500">
+          <span>By <strong class="text-charcoal"><%= post.user.display_name %></strong></span>
+          <span>&middot;</span>
+          <% if post.published_at.present? %>
+            <time datetime="<%= post.published_at.iso8601 %>"><%= post.published_at.strftime("%B %-d, %Y") %></time>
+          <% else %>
+            <span class="italic">Draft</span>
+          <% end %>
+          <span>&middot;</span>
+          <span><%= post.reading_time_minutes %> min read</span>
+          <% if post.category %>
+            <span>&middot;</span>
+            <span class="text-ink-blue"><%= post.category.name %></span>
+          <% end %>
+        </div>
+      </header>
+
+      <% if post.featured_image.attached? %>
+        <div class="mb-8">
+          <%= image_tag post.featured_image, class: "w-full rounded-lg", alt: post.title %>
+        </div>
+      <% end %>
+
+      <div class="prose prose-lg max-w-none prose-headings:font-display prose-a:text-ink-blue"
+           data-controller="x-post-widget">
+        <%= post.content %>
+      </div>
+
+      <% if post.tags.any? %>
+        <footer class="mt-8 border-t border-gray-200 pt-6">
+          <div class="flex flex-wrap gap-2">
+            <% post.tags.each do |tag| %>
+              <span class="inline-block rounded-full bg-gray-100 px-3 py-1 text-sm text-gray-700"><%= tag.name %></span>
+            <% end %>
+          </div>
+        </footer>
+      <% end %>
+    </article>
+  </div>
+</div>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,3 +1,22 @@
 <% content_for(:title, "Edit Post — #{site_name}") %>
 
-<%= render "form", post: @post %>
+<% if @post.persisted? %>
+  <% content_for(:top_bar_actions) do %>
+    <button type="button"
+            data-post-preview-target="toggleButton"
+            data-action="click->post-preview#toggle"
+            class="inline-flex items-center gap-1.5 rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none">
+      <svg data-post-preview-target="toggleIcon" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+      </svg>
+      <span data-post-preview-target="toggleLabel">Preview</span>
+    </button>
+  <% end %>
+<% end %>
+
+<div data-post-preview-target="editor">
+  <%= render "form", post: @post %>
+</div>
+
+<div data-post-preview-target="preview" class="hidden"></div>

--- a/app/views/layouts/admin_editor.html.erb
+++ b/app/views/layouts/admin_editor.html.erb
@@ -19,7 +19,7 @@
 
   <body class="h-full">
     <% ai_available = SiteSetting.current.ai_configured? && @post&.persisted? %>
-    <div data-controller="autosave editor-drawer"
+    <div data-controller="autosave editor-drawer post-preview"
          data-autosave-back-url-value="<%= admin_posts_path %>"
          <% if @post&.persisted? %>
            data-autosave-url-value="<%= admin_post_path(@post) %>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     resource :setup, only: [ :new, :create ], controller: "setup"
     resource :session, only: [ :new, :create, :destroy ]
     resources :posts do
+      member do
+        get :preview
+      end
       resource :dashboard, only: [ :show ], controller: "post_dashboard"
       namespace :ai do
         resource :conversation, only: [ :show, :create ]


### PR DESCRIPTION
## Summary
- Adds a **Preview** toggle button to the editor top bar that renders the post as it would appear on the public site, without publishing or tracking views
- Preview fetches server-rendered HTML after autosaving, swapping the editor form (hidden, not destroyed) for a cream-background preview with public typography
- Keyboard shortcut `Cmd+Shift+P` / `Ctrl+Shift+P` toggles between edit and preview modes

## Test plan
- [ ] Create a draft post with title, content, and featured image — click Preview and verify it renders with public styling and cream background
- [ ] Click Edit and verify the editor form is restored with content intact
- [ ] Verify `Cmd+Shift+P` toggles preview on/off
- [ ] Verify the Preview button does not appear on the new post page
- [ ] Verify no `PostView` records are created after previewing
- [ ] Verify posts with nil `published_at` show "Draft" instead of a date
- [ ] Run `bin/rails test` — all 330 tests pass
- [ ] Run `bin/rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)