### PR TITLE
Add full-text search with SQLite FTS5

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -16,9 +16,7 @@ module Admin
         @posts = @posts.draft
       end
 
-      if params[:search].present?
-        @posts = @posts.where("title LIKE ?", "%#{Post.sanitize_sql_like(params[:search])}%")
-      end
+      @posts = @posts.search(params[:search]) if params[:search].present?
 
       @posts = @posts.order(updated_at: :desc)
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,6 +15,8 @@ class PostsController < ApplicationController
     @posts = all_posts.offset(offset).limit(PER_PAGE)
     @next_page = @page + 1 if all_posts.offset(offset + PER_PAGE).exists?
 
+    @snippets = @query ? Post.search_with_snippets(@query) : {}
+
     if turbo_frame_request_id&.start_with?("posts_page_")
       render partial: "posts/post_page", locals: { posts: @posts, page: @page, next_page: @next_page, query: @query }, layout: false
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   include Sluggable
   include Publishable
+  include Searchable
 
   enum :status, { draft: 0, scheduled: 1, published: 2 }
 
@@ -29,16 +30,13 @@ class Post < ApplicationRecord
 
   scope :featured, -> { where(featured: true) }
   scope :by_publication_date, -> { order(published_at: :desc) }
-  scope :search, ->(query) {
-    where("title LIKE :q OR subtitle LIKE :q", q: "%#{sanitize_sql_like(query)}%")
-  }
 
   before_save :calculate_reading_time
 
   private
 
   def calculate_reading_time
-    text = content&.to_plain_text.to_s
+    text = body_plain.to_s
     words = text.split.size
     self.reading_time_minutes = [ (words / 238.0).ceil, 1 ].max
   end

--- a/app/models/post/search_result.rb
+++ b/app/models/post/search_result.rb
@@ -1,0 +1,1 @@
+Post::SearchResult = Struct.new(:post, :title_snippet, :subtitle_snippet, :body_snippet, keyword_init: true)

--- a/app/models/post/searchable.rb
+++ b/app/models/post/searchable.rb
@@ -1,0 +1,59 @@
+module Post::Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :update_body_plain
+
+    scope :search, ->(query) {
+      return none if query.blank?
+
+      sanitized = klass.send(:fts_query, query)
+      where("id IN (SELECT rowid FROM posts_fts WHERE posts_fts MATCH ?)", sanitized)
+        .order(Arel.sql("(SELECT rank FROM posts_fts WHERE posts_fts MATCH #{connection.quote(sanitized)} AND rowid = posts.id)"))
+    }
+  end
+
+  class_methods do
+    def search_with_snippets(query)
+      return {} if query.blank?
+
+      sanitized = fts_query(query)
+      sql = sanitize_sql_array([
+        <<~SQL, sanitized, 100
+          SELECT
+            rowid,
+            snippet(posts_fts, 0, '<mark>', '</mark>', '...', 32) AS title_snippet,
+            snippet(posts_fts, 1, '<mark>', '</mark>', '...', 32) AS subtitle_snippet,
+            snippet(posts_fts, 2, '<mark>', '</mark>', '...', 32) AS body_snippet
+          FROM posts_fts
+          WHERE posts_fts MATCH ?
+          ORDER BY rank
+          LIMIT ?
+        SQL
+      ])
+      results = connection.select_all(sql)
+
+      results.each_with_object({}) do |row, hash|
+        hash[row["rowid"].to_i] = Post::SearchResult.new(
+          title_snippet: row["title_snippet"],
+          subtitle_snippet: row["subtitle_snippet"],
+          body_snippet: row["body_snippet"]
+        )
+      end
+    end
+
+    private
+
+    def fts_query(query)
+      tokens = query.to_s.strip.split(/\s+/).map { |t| %("#{t.gsub('"', '""')}") }
+      tokens[-1] = tokens[-1] + "*" if tokens.any?
+      tokens.join(" ")
+    end
+  end
+
+  private
+
+  def update_body_plain
+    self.body_plain = content&.to_plain_text.to_s
+  end
+end

--- a/app/services/mcp/tools/list_posts.rb
+++ b/app/services/mcp/tools/list_posts.rb
@@ -8,7 +8,7 @@ module Mcp
           status: { type: "string", enum: %w[draft scheduled published], description: "Filter by post status" },
           category: { type: "string", description: "Filter by category name" },
           tag: { type: "string", description: "Filter by tag name" },
-          search: { type: "string", description: "Search posts by title or subtitle" },
+          search: { type: "string", description: "Search posts by title, subtitle, or body content" },
           page: { type: "integer", description: "Page number (default: 1)", minimum: 1 },
           per_page: { type: "integer", description: "Results per page (default: 20, max: 50)", minimum: 1, maximum: 50 }
         }

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -6,6 +6,17 @@
     <%= link_to "New Post", new_admin_post_path, class: "rounded-md bg-gray-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-700" %>
   </div>
 
+  <%# Search %>
+  <div>
+    <%= form_tag admin_posts_path, method: :get, class: "flex items-center gap-2" do %>
+      <% if params[:status].present? %>
+        <input type="hidden" name="status" value="<%= params[:status] %>">
+      <% end %>
+      <input type="search" name="search" value="<%= params[:search] %>" placeholder="Search posts..." class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-900 sm:max-w-xs sm:text-sm sm:leading-6">
+      <button type="submit" class="rounded-md bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-200">Search</button>
+    <% end %>
+  </div>
+
   <%# Status tabs %>
   <div class="border-b border-gray-200">
     <nav class="-mb-px flex space-x-8">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -18,4 +18,7 @@
       <% end %>
     </div>
   </header>
+  <% if defined?(@snippets) && @snippets[post.id]&.body_snippet.present? %>
+    <p class="mt-3 text-sm text-gray-600 leading-relaxed"><%= sanitize @snippets[post.id].body_snippet, tags: %w[mark] %></p>
+  <% end %>
 </article>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ module Prose
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.active_record.schema_format = :sql
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/db/migrate/20260219222045_create_you_tube_videos.rb
+++ b/db/migrate/20260219222045_create_you_tube_videos.rb
@@ -1,4 +1,4 @@
-class CreateYoutubeVideos < ActiveRecord::Migration[8.1]
+class CreateYouTubeVideos < ActiveRecord::Migration[8.1]
   def change
     create_table :youtube_videos do |t|
       t.string :url, null: false

--- a/db/migrate/20260223000001_add_body_plain_to_posts.rb
+++ b/db/migrate/20260223000001_add_body_plain_to_posts.rb
@@ -1,0 +1,5 @@
+class AddBodyPlainToPosts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :posts, :body_plain, :text
+  end
+end

--- a/db/migrate/20260223000002_create_posts_fts_index.rb
+++ b/db/migrate/20260223000002_create_posts_fts_index.rb
@@ -1,0 +1,43 @@
+class CreatePostsFtsIndex < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      CREATE VIRTUAL TABLE posts_fts USING fts5(
+        title,
+        subtitle,
+        body_plain,
+        content='posts',
+        content_rowid='id'
+      );
+    SQL
+
+    execute <<~SQL
+      CREATE TRIGGER posts_fts_insert AFTER INSERT ON posts BEGIN
+        INSERT INTO posts_fts(rowid, title, subtitle, body_plain)
+        VALUES (NEW.id, NEW.title, NEW.subtitle, NEW.body_plain);
+      END;
+    SQL
+
+    execute <<~SQL
+      CREATE TRIGGER posts_fts_update AFTER UPDATE ON posts BEGIN
+        INSERT INTO posts_fts(posts_fts, rowid, title, subtitle, body_plain)
+        VALUES ('delete', OLD.id, OLD.title, OLD.subtitle, OLD.body_plain);
+        INSERT INTO posts_fts(rowid, title, subtitle, body_plain)
+        VALUES (NEW.id, NEW.title, NEW.subtitle, NEW.body_plain);
+      END;
+    SQL
+
+    execute <<~SQL
+      CREATE TRIGGER posts_fts_delete AFTER DELETE ON posts BEGIN
+        INSERT INTO posts_fts(posts_fts, rowid, title, subtitle, body_plain)
+        VALUES ('delete', OLD.id, OLD.title, OLD.subtitle, OLD.body_plain);
+      END;
+    SQL
+  end
+
+  def down
+    execute "DROP TRIGGER IF EXISTS posts_fts_delete"
+    execute "DROP TRIGGER IF EXISTS posts_fts_update"
+    execute "DROP TRIGGER IF EXISTS posts_fts_insert"
+    execute "DROP TABLE IF EXISTS posts_fts"
+  end
+end

--- a/db/migrate/20260223000003_backfill_posts_body_plain.rb
+++ b/db/migrate/20260223000003_backfill_posts_body_plain.rb
@@ -1,0 +1,15 @@
+class BackfillPostsBodyPlain < ActiveRecord::Migration[8.1]
+  def up
+    Post.find_each do |post|
+      plain_text = post.content&.to_plain_text.to_s
+      post.update_column(:body_plain, plain_text)
+    end
+
+    execute "INSERT INTO posts_fts(posts_fts) VALUES ('rebuild')"
+  end
+
+  def down
+    execute "INSERT INTO posts_fts(posts_fts) VALUES ('rebuild')"
+    execute "UPDATE posts SET body_plain = NULL"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,210 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE IF NOT EXISTS "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "user_id" integer NOT NULL, "token" varchar NOT NULL, "ip_address" varchar, "user_agent" varchar, "expires_at" datetime(6) NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_758836b4f0"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+);
+CREATE INDEX "index_sessions_on_user_id" ON "sessions" ("user_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_sessions_on_token" ON "sessions" ("token") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "active_storage_blobs" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "key" varchar NOT NULL, "filename" varchar NOT NULL, "content_type" varchar, "metadata" text, "service_name" varchar NOT NULL, "byte_size" bigint NOT NULL, "checksum" varchar, "created_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_active_storage_blobs_on_key" ON "active_storage_blobs" ("key") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "active_storage_attachments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "record_type" varchar NOT NULL, "record_id" bigint NOT NULL, "blob_id" bigint NOT NULL, "created_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_c3b3935057"
+FOREIGN KEY ("blob_id")
+  REFERENCES "active_storage_blobs" ("id")
+);
+CREATE INDEX "index_active_storage_attachments_on_blob_id" ON "active_storage_attachments" ("blob_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_active_storage_attachments_uniqueness" ON "active_storage_attachments" ("record_type", "record_id", "name", "blob_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "active_storage_variant_records" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "blob_id" bigint NOT NULL, "variation_digest" varchar NOT NULL, CONSTRAINT "fk_rails_993965df05"
+FOREIGN KEY ("blob_id")
+  REFERENCES "active_storage_blobs" ("id")
+);
+CREATE UNIQUE INDEX "index_active_storage_variant_records_uniqueness" ON "active_storage_variant_records" ("blob_id", "variation_digest") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "action_text_rich_texts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "body" text, "record_type" varchar NOT NULL, "record_id" bigint NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_action_text_rich_texts_uniqueness" ON "action_text_rich_texts" ("record_type", "record_id", "name") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "categories" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "slug" varchar NOT NULL, "description" text, "position" integer DEFAULT 0 NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_categories_on_slug" ON "categories" ("slug") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "tags" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "slug" varchar NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_tags_on_slug" ON "tags" ("slug") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "posts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "subtitle" varchar, "slug" varchar NOT NULL, "status" integer DEFAULT 0 NOT NULL, "published_at" datetime(6), "scheduled_at" datetime(6), "featured" boolean DEFAULT FALSE NOT NULL, "reading_time_minutes" integer DEFAULT 0, "category_id" integer, "user_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "loves_count" integer DEFAULT 0 NOT NULL /*application='Prose'*/, "meta_description" text /*application='Prose'*/, "body_plain" text /*application='Prose'*/, CONSTRAINT "fk_rails_9b1b26f040"
+FOREIGN KEY ("category_id")
+  REFERENCES "categories" ("id")
+, CONSTRAINT "fk_rails_5b5ddfd518"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+);
+CREATE INDEX "index_posts_on_category_id" ON "posts" ("category_id") /*application='Prose'*/;
+CREATE INDEX "index_posts_on_user_id" ON "posts" ("user_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_posts_on_slug" ON "posts" ("slug") /*application='Prose'*/;
+CREATE INDEX "index_posts_on_status" ON "posts" ("status") /*application='Prose'*/;
+CREATE INDEX "index_posts_on_published_at" ON "posts" ("published_at") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "post_tags" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer NOT NULL, "tag_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_fdf74b486b"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+, CONSTRAINT "fk_rails_c9d8c5063e"
+FOREIGN KEY ("tag_id")
+  REFERENCES "tags" ("id")
+);
+CREATE INDEX "index_post_tags_on_post_id" ON "post_tags" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_post_tags_on_tag_id" ON "post_tags" ("tag_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_post_tags_on_post_id_and_tag_id" ON "post_tags" ("post_id", "tag_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "post_views" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer NOT NULL, "ip_hash" varchar, "user_agent" varchar, "referrer" varchar, "source" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_f2f2d28c2c"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+);
+CREATE INDEX "index_post_views_on_post_id" ON "post_views" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_post_views_on_created_at" ON "post_views" ("created_at") /*application='Prose'*/;
+CREATE INDEX "index_post_views_on_post_id_and_created_at" ON "post_views" ("post_id", "created_at") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "identities" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL, "handle" varchar, "settings" json DEFAULT '{}', "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_identities_on_handle" ON "identities" ("handle") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "comments" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer NOT NULL, "parent_comment_id" integer, "body" text NOT NULL, "approved" boolean DEFAULT TRUE NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "identity_id" integer NOT NULL, CONSTRAINT "fk_rails_2530bf1cd4"
+FOREIGN KEY ("identity_id")
+  REFERENCES "identities" ("id")
+, CONSTRAINT "fk_rails_2fd19c0db7"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+, CONSTRAINT "fk_rails_da28d53ee7"
+FOREIGN KEY ("parent_comment_id")
+  REFERENCES "comments" ("id")
+);
+CREATE INDEX "index_comments_on_post_id" ON "comments" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_comments_on_parent_comment_id" ON "comments" ("parent_comment_id") /*application='Prose'*/;
+CREATE INDEX "index_comments_on_identity_id" ON "comments" ("identity_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "loves" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "identity_id" integer NOT NULL, CONSTRAINT "fk_rails_398ba21e55"
+FOREIGN KEY ("identity_id")
+  REFERENCES "identities" ("id")
+, CONSTRAINT "fk_rails_c2ec4c8c1b"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+);
+CREATE INDEX "index_loves_on_post_id" ON "loves" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_loves_on_identity_id" ON "loves" ("identity_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_loves_on_post_id_and_identity_id" ON "loves" ("post_id", "identity_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "users" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "email" varchar NOT NULL, "password_digest" varchar NOT NULL, "role" integer DEFAULT 1 NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "identity_id" integer NOT NULL, CONSTRAINT "fk_rails_2f296ee649"
+FOREIGN KEY ("identity_id")
+  REFERENCES "identities" ("id")
+);
+CREATE UNIQUE INDEX "index_users_on_email" ON "users" ("email") /*application='Prose'*/;
+CREATE INDEX "index_users_on_identity_id" ON "users" ("identity_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "site_settings" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "site_name" varchar DEFAULT 'Prose' NOT NULL, "site_description" text DEFAULT '', "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "heading_font" varchar DEFAULT 'Playfair Display' /*application='Prose'*/, "subtitle_font" varchar DEFAULT 'Source Serif 4' /*application='Prose'*/, "body_font" varchar DEFAULT 'Source Serif 4' /*application='Prose'*/, "heading_font_size" decimal(4,2) DEFAULT 2.25 /*application='Prose'*/, "subtitle_font_size" decimal(4,2) DEFAULT 1.25 /*application='Prose'*/, "body_font_size" decimal(4,2) DEFAULT 1.13 /*application='Prose'*/, "claude_api_key" varchar /*application='Prose'*/, "gemini_api_key" varchar /*application='Prose'*/, "ai_model" varchar DEFAULT 'claude-sonnet-4-5-20250929' /*application='Prose'*/, "ai_max_tokens" integer DEFAULT 4096 /*application='Prose'*/, "openai_api_key" varchar /*application='Prose'*/, "image_model" varchar DEFAULT 'imagen-4.0-generate-001' /*application='Prose'*/, "background_color" varchar DEFAULT 'cream' /*application='Prose'*/);
+CREATE TABLE IF NOT EXISTS "models" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "model_id" varchar NOT NULL, "name" varchar NOT NULL, "provider" varchar NOT NULL, "family" varchar, "model_created_at" datetime(6), "context_window" integer, "max_output_tokens" integer, "knowledge_cutoff" date, "modalities" json DEFAULT '{}', "capabilities" json DEFAULT '[]', "pricing" json DEFAULT '{}', "metadata" json DEFAULT '{}', "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_models_on_provider_and_model_id" ON "models" ("provider", "model_id") /*application='Prose'*/;
+CREATE INDEX "index_models_on_provider" ON "models" ("provider") /*application='Prose'*/;
+CREATE INDEX "index_models_on_family" ON "models" ("family") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "tool_calls" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "tool_call_id" varchar NOT NULL, "name" varchar NOT NULL, "thought_signature" varchar, "arguments" json DEFAULT '{}', "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "message_id" integer NOT NULL, CONSTRAINT "fk_rails_9c8daee481"
+FOREIGN KEY ("message_id")
+  REFERENCES "messages" ("id")
+);
+CREATE UNIQUE INDEX "index_tool_calls_on_tool_call_id" ON "tool_calls" ("tool_call_id") /*application='Prose'*/;
+CREATE INDEX "index_tool_calls_on_name" ON "tool_calls" ("name") /*application='Prose'*/;
+CREATE INDEX "index_tool_calls_on_message_id" ON "tool_calls" ("message_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "role" varchar NOT NULL, "content" text, "content_raw" json, "thinking_text" text, "thinking_signature" text, "thinking_tokens" integer, "input_tokens" integer, "output_tokens" integer, "cached_tokens" integer, "cache_creation_tokens" integer, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "chat_id" integer NOT NULL, "model_id" integer, "tool_call_id" integer, CONSTRAINT "fk_rails_c02b47ad97"
+FOREIGN KEY ("model_id")
+  REFERENCES "models" ("id")
+, CONSTRAINT "fk_rails_0f670de7ba"
+FOREIGN KEY ("chat_id")
+  REFERENCES "chats" ("id")
+, CONSTRAINT "fk_rails_552873cb52"
+FOREIGN KEY ("tool_call_id")
+  REFERENCES "tool_calls" ("id")
+);
+CREATE INDEX "index_messages_on_role" ON "messages" ("role") /*application='Prose'*/;
+CREATE INDEX "index_messages_on_chat_id" ON "messages" ("chat_id") /*application='Prose'*/;
+CREATE INDEX "index_messages_on_model_id" ON "messages" ("model_id") /*application='Prose'*/;
+CREATE INDEX "index_messages_on_tool_call_id" ON "messages" ("tool_call_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "chats" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "model_id" integer, "post_id" integer, "user_id" integer, "conversation_type" varchar DEFAULT 'chat' NOT NULL /*application='Prose'*/, CONSTRAINT "fk_rails_b19b85f418"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+, CONSTRAINT "fk_rails_1835d93df1"
+FOREIGN KEY ("model_id")
+  REFERENCES "models" ("id")
+, CONSTRAINT "fk_rails_e555f43151"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+);
+CREATE INDEX "index_chats_on_model_id" ON "chats" ("model_id") /*application='Prose'*/;
+CREATE INDEX "index_chats_on_post_id" ON "chats" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_chats_on_user_id" ON "chats" ("user_id") /*application='Prose'*/;
+CREATE INDEX "index_chats_on_post_id_and_user_id_and_conversation_type" ON "chats" ("post_id", "user_id", "conversation_type") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "x_posts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "url" varchar NOT NULL, "embed_html" text, "author_name" varchar, "author_username" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_x_posts_on_url" ON "x_posts" ("url") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "youtube_videos" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "url" varchar NOT NULL, "video_id" varchar NOT NULL, "title" varchar, "author_name" varchar, "thumbnail_url" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_youtube_videos_on_url" ON "youtube_videos" ("url") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "subscribers" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "email" varchar NOT NULL, "confirmed_at" datetime(6), "auth_token" varchar, "auth_token_sent_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "identity_id" integer NOT NULL, "source_post_id" integer, CONSTRAINT "fk_rails_5fff778d93"
+FOREIGN KEY ("identity_id")
+  REFERENCES "identities" ("id")
+, CONSTRAINT "fk_rails_f1d772a46a"
+FOREIGN KEY ("source_post_id")
+  REFERENCES "posts" ("id")
+);
+CREATE UNIQUE INDEX "index_subscribers_on_email" ON "subscribers" ("email") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_subscribers_on_auth_token" ON "subscribers" ("auth_token") /*application='Prose'*/;
+CREATE INDEX "index_subscribers_on_identity_id" ON "subscribers" ("identity_id") /*application='Prose'*/;
+CREATE INDEX "index_subscribers_on_source_post_id" ON "subscribers" ("source_post_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "api_tokens" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "user_id" integer NOT NULL, "name" varchar NOT NULL, "token_digest" varchar NOT NULL, "token_prefix" varchar NOT NULL, "last_used_at" datetime(6), "last_used_ip" varchar, "revoked_at" datetime(6), "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_f16b5e0447"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+);
+CREATE INDEX "index_api_tokens_on_user_id" ON "api_tokens" ("user_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_api_tokens_on_token_digest" ON "api_tokens" ("token_digest") /*application='Prose'*/;
+CREATE VIRTUAL TABLE posts_fts USING fts5(
+  title,
+  subtitle,
+  body_plain,
+  content='posts',
+  content_rowid='id'
+)
+/* posts_fts(title,subtitle,body_plain) */;
+CREATE TABLE IF NOT EXISTS 'posts_fts_data'(id INTEGER PRIMARY KEY, block BLOB);
+CREATE TABLE IF NOT EXISTS 'posts_fts_idx'(segid, term, pgno, PRIMARY KEY(segid, term)) WITHOUT ROWID;
+CREATE TABLE IF NOT EXISTS 'posts_fts_docsize'(id INTEGER PRIMARY KEY, sz BLOB);
+CREATE TABLE IF NOT EXISTS 'posts_fts_config'(k PRIMARY KEY, v) WITHOUT ROWID;
+CREATE TRIGGER posts_fts_insert AFTER INSERT ON posts BEGIN
+  INSERT INTO posts_fts(rowid, title, subtitle, body_plain)
+  VALUES (NEW.id, NEW.title, NEW.subtitle, NEW.body_plain);
+END;
+CREATE TRIGGER posts_fts_update AFTER UPDATE ON posts BEGIN
+  INSERT INTO posts_fts(posts_fts, rowid, title, subtitle, body_plain)
+  VALUES ('delete', OLD.id, OLD.title, OLD.subtitle, OLD.body_plain);
+  INSERT INTO posts_fts(rowid, title, subtitle, body_plain)
+  VALUES (NEW.id, NEW.title, NEW.subtitle, NEW.body_plain);
+END;
+CREATE TRIGGER posts_fts_delete AFTER DELETE ON posts BEGIN
+  INSERT INTO posts_fts(posts_fts, rowid, title, subtitle, body_plain)
+  VALUES ('delete', OLD.id, OLD.title, OLD.subtitle, OLD.body_plain);
+END;
+INSERT INTO "schema_migrations" (version) VALUES
+('20260223000003'),
+('20260223000002'),
+('20260223000001'),
+('20260221144107'),
+('20260220192258'),
+('20260220192218'),
+('20260219222045'),
+('20260219201804'),
+('20260219015524'),
+('20260219015523'),
+('20260219015522'),
+('20260219015521'),
+('20260219015520'),
+('20260219015519'),
+('20260219015518'),
+('20260219015517'),
+('20260218211848'),
+('20260218170100'),
+('20260218170000'),
+('20260218160100'),
+('20260218160000'),
+('20260218152710'),
+('20260218151505'),
+('20260218151433'),
+('20260218151432'),
+('20260218151032'),
+('20260218150338'),
+('20260218150337'),
+('20260218150336'),
+('20260218150331'),
+('20260218150324'),
+('20260218150323'),
+('20260218145818'),
+('20260218145802');
+

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -42,4 +42,21 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     get post_path(posts(:published_post), slug: posts(:published_post).slug)
     assert_select "script[type='application/ld+json']"
   end
+
+  test "GET index with search query filters results" do
+    get root_path(q: "Published")
+    assert_response :success
+    assert_select "h3", text: posts(:published_post).title
+  end
+
+  test "GET index with search shows body snippet" do
+    get root_path(q: "innovation")
+    assert_response :success
+    assert_select "mark"
+  end
+
+  test "GET index with non-matching search shows no posts" do
+    get root_path(q: "xyznonexistent")
+    assert_response :success
+  end
 end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -6,6 +6,7 @@ published_post:
   published_at: <%= 1.day.ago %>
   featured: false
   reading_time_minutes: 3
+  body_plain: "This is the body content of the published post about technology and innovation."
   user: admin
   category: technology
 
@@ -15,6 +16,7 @@ draft_post:
   status: 0
   featured: false
   reading_time_minutes: 1
+  body_plain: "Draft content about quantum computing and artificial intelligence."
   user: writer
 
 scheduled_post:
@@ -24,6 +26,7 @@ scheduled_post:
   scheduled_at: <%= 1.day.from_now %>
   featured: false
   reading_time_minutes: 2
+  body_plain: "Scheduled content discussing upcoming features and improvements."
   user: admin
 
 featured_post:
@@ -33,5 +36,6 @@ featured_post:
   published_at: <%= 2.hours.ago %>
   featured: true
   reading_time_minutes: 5
+  body_plain: "Featured article exploring advanced programming patterns and best practices."
   user: admin
   category: technology

--- a/test/models/post/searchable_test.rb
+++ b/test/models/post/searchable_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Post::SearchableTest < ActiveSupport::TestCase
+  test "search finds posts by title" do
+    results = Post.search("Published")
+    assert_includes results, posts(:published_post)
+  end
+
+  test "search finds posts by subtitle" do
+    results = Post.search("published article")
+    assert_includes results, posts(:published_post)
+  end
+
+  test "search finds posts by body content" do
+    results = Post.search("quantum computing")
+    assert_includes results, posts(:draft_post)
+  end
+
+  test "search returns empty for no match" do
+    results = Post.search("xyznonexistent")
+    assert_empty results
+  end
+
+  test "search returns none for blank query" do
+    assert_empty Post.search("")
+    assert_empty Post.search(nil)
+  end
+
+  test "search handles special characters safely" do
+    results = Post.search('test "quotes" here')
+    assert_kind_of ActiveRecord::Relation, results
+  end
+
+  test "search supports prefix matching on last token" do
+    results = Post.search("innov")
+    assert_includes results, posts(:published_post)
+  end
+
+  test "search chains with other scopes" do
+    results = Post.published.search("Post")
+    assert_includes results, posts(:published_post)
+    refute_includes results, posts(:draft_post)
+  end
+
+  test "search_with_snippets returns hash with search results" do
+    snippets = Post.search_with_snippets("quantum")
+    assert snippets.key?(posts(:draft_post).id)
+
+    result = snippets[posts(:draft_post).id]
+    assert_kind_of Post::SearchResult, result
+    assert_includes result.body_snippet, "<mark>"
+  end
+
+  test "search_with_snippets returns empty hash for blank query" do
+    assert_equal({}, Post.search_with_snippets(""))
+    assert_equal({}, Post.search_with_snippets(nil))
+  end
+
+  test "body_plain is updated on save" do
+    post = posts(:published_post)
+    post.update!(content: "<p>New body content here</p>")
+    assert_equal "New body content here", post.reload.body_plain
+  end
+end


### PR DESCRIPTION
## Summary

- Replace LIKE-based search with SQLite FTS5 for full-text search across post titles, subtitles, and body content
- Add BM25 ranking, `<mark>` snippet highlighting on public search results, and prefix matching on the last token
- Add search input to admin posts index with status filter preservation
- Switch schema format to `structure.sql` to support FTS5 virtual tables and triggers

Closes #25

## Test plan

- [x] Search for a word that only appears in post body content on the public site — verify results appear with highlighted snippets
- [x] Verify admin post search finds posts by title, subtitle, and body content
- [x] Verify status tab filters are preserved when searching in admin
- [x] Run `bin/rails test` — all 352 tests pass
- [x] Run `bin/rubocop` — no offenses on changed files
- [x] Run `bin/brakeman` — 0 security warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)