### PR TITLE
Related posts and next/previous post navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ app/models/user.rb                    # class User includes concerns
 app/models/user/named.rb              # module User::Named (concern)
 app/models/user/authenticatable.rb    # module User::Authenticatable (concern)
 app/models/user/api_tokenable.rb     # module User::ApiTokenable (concern)
+app/models/post/discoverable.rb      # module Post::Discoverable (related posts, prev/next)
 app/models/api_token.rb              # Token generation, digest lookup, revocation
 ```
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,6 +24,9 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.live.includes(:user, :category, :tags).find_by!(slug: params[:slug])
+    @related_posts = @post.related_posts
+    @previous_post = @post.previous_post
+    @next_post = @post.next_post
     track_post_view(@post)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   include Sluggable
   include Publishable
   include Searchable
+  include Discoverable
 
   enum :status, { draft: 0, scheduled: 1, published: 2 }
 

--- a/app/models/post/discoverable.rb
+++ b/app/models/post/discoverable.rb
@@ -1,0 +1,62 @@
+module Post::Discoverable
+  extend ActiveSupport::Concern
+
+  def related_posts(limit: 3)
+    candidates = tag_matched_posts(limit)
+    candidates = backfill_with_category(candidates, limit) if candidates.size < limit
+    candidates = backfill_with_recent(candidates, limit) if candidates.size < limit
+    candidates
+  end
+
+  def previous_post
+    Post.live.where("published_at < ?", published_at).order(published_at: :desc).first
+  end
+
+  def next_post
+    Post.live.where("published_at > ?", published_at).order(published_at: :asc).first
+  end
+
+  private
+
+  def tag_matched_posts(limit)
+    return Post.none.to_a if tag_ids.empty?
+
+    Post.live
+        .where.not(id: id)
+        .joins(:tags)
+        .where(tags: { id: tag_ids })
+        .group("posts.id")
+        .order(Arel.sql("COUNT(tags.id) DESC, posts.published_at DESC"))
+        .limit(limit)
+        .to_a
+  end
+
+  def backfill_with_category(candidates, limit)
+    return candidates if category_id.blank?
+
+    exclude_ids = [ id ] + candidates.map(&:id)
+    remaining = limit - candidates.size
+
+    category_posts = Post.live
+                         .where(category_id: category_id)
+                         .where.not(id: exclude_ids)
+                         .order(published_at: :desc)
+                         .limit(remaining)
+                         .to_a
+
+    candidates + category_posts
+  end
+
+  def backfill_with_recent(candidates, limit)
+    exclude_ids = [ id ] + candidates.map(&:id)
+    remaining = limit - candidates.size
+
+    recent_posts = Post.live
+                       .where.not(id: exclude_ids)
+                       .order(published_at: :desc)
+                       .limit(remaining)
+                       .to_a
+
+    candidates + recent_posts
+  end
+end

--- a/app/views/posts/_post_navigation.html.erb
+++ b/app/views/posts/_post_navigation.html.erb
@@ -1,0 +1,22 @@
+<% if previous_post || next_post %>
+  <nav class="mt-10 border-t border-gray-200 dark:border-gray-700 pt-8" aria-label="Post navigation">
+    <div class="flex justify-between items-start gap-8">
+      <div class="flex-1 min-w-0">
+        <% if previous_post %>
+          <%= link_to post_path(previous_post, slug: previous_post.slug), class: "group block" do %>
+            <span class="text-sm text-gray-500 dark:text-gray-400">&larr; Previous Post</span>
+            <p class="mt-1 font-display font-bold text-charcoal group-hover:text-ink-blue transition-colors truncate"><%= previous_post.title %></p>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="flex-1 min-w-0 text-right">
+        <% if next_post %>
+          <%= link_to post_path(next_post, slug: next_post.slug), class: "group block" do %>
+            <span class="text-sm text-gray-500 dark:text-gray-400">Next Post &rarr;</span>
+            <p class="mt-1 font-display font-bold text-charcoal group-hover:text-ink-blue transition-colors truncate"><%= next_post.title %></p>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </nav>
+<% end %>

--- a/app/views/posts/_related_posts.html.erb
+++ b/app/views/posts/_related_posts.html.erb
@@ -1,0 +1,27 @@
+<% if related_posts.any? %>
+  <section class="mt-10 border-t border-gray-200 dark:border-gray-700 pt-8">
+    <h3 class="font-display text-xl font-bold mb-6">You might also like</h3>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+      <% related_posts.each do |post| %>
+        <article>
+          <% if post.featured_image.attached? %>
+            <%= link_to post_path(post, slug: post.slug) do %>
+              <%= image_tag post.featured_image.variant(resize_to_fill: [400, 225]),
+                    class: "w-full aspect-video object-cover rounded-lg",
+                    alt: post.title,
+                    loading: "lazy" %>
+            <% end %>
+          <% end %>
+          <h4 class="font-display font-bold mt-3 leading-snug">
+            <%= link_to post.title, post_path(post, slug: post.slug),
+                  class: "text-charcoal hover:text-ink-blue transition-colors" %>
+          </h4>
+          <time class="text-sm text-gray-500 dark:text-gray-400 mt-1 block"
+                datetime="<%= post.published_at.iso8601 %>">
+            <%= post.published_at.strftime("%B %-d, %Y") %>
+          </time>
+        </article>
+      <% end %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -51,6 +51,9 @@
     <%= render "loves/button", post: @post %>
   </div>
 
+  <%= render "posts/post_navigation", previous_post: @previous_post, next_post: @next_post %>
+  <%= render "posts/related_posts", related_posts: @related_posts %>
+
   <%# Comments %>
   <div class="mt-8 border-t border-gray-200 dark:border-gray-700 pt-6">
     <h3 class="font-display text-xl font-bold">Comments</h3>

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,3 +1,27 @@
 published_ruby:
   post: published_post
   tag: ruby
+
+published_rails:
+  post: published_post
+  tag: rails
+
+related_ruby_ruby:
+  post: related_ruby_post
+  tag: ruby
+
+related_ruby_rails:
+  post: related_ruby_post
+  tag: rails
+
+related_rails_rails:
+  post: related_rails_post
+  tag: rails
+
+featured_ruby:
+  post: featured_post
+  tag: ruby
+
+design_css:
+  post: design_post
+  tag: css

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -39,3 +39,36 @@ featured_post:
   body_plain: "Featured article exploring advanced programming patterns and best practices."
   user: admin
   category: technology
+
+related_ruby_post:
+  title: Ruby Tips and Tricks
+  slug: ruby-tips-and-tricks
+  status: 2
+  published_at: <%= 3.days.ago %>
+  featured: false
+  reading_time_minutes: 4
+  body_plain: "A collection of useful Ruby tips."
+  user: admin
+  category: technology
+
+related_rails_post:
+  title: Rails Best Practices
+  slug: rails-best-practices
+  status: 2
+  published_at: <%= 5.days.ago %>
+  featured: false
+  reading_time_minutes: 6
+  body_plain: "Best practices for building Rails applications."
+  user: writer
+  category: technology
+
+design_post:
+  title: Modern UI Design
+  slug: modern-ui-design
+  status: 2
+  published_at: <%= 4.days.ago %>
+  featured: false
+  reading_time_minutes: 3
+  body_plain: "Exploring modern UI design patterns."
+  user: admin
+  category: design

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -5,3 +5,7 @@ ruby:
 rails:
   name: Rails
   slug: rails
+
+css:
+  name: CSS
+  slug: css

--- a/test/models/post/discoverable_test.rb
+++ b/test/models/post/discoverable_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class Post::DiscoverableTest < ActiveSupport::TestCase
+  # Fixtures:
+  # published_post: published 1 day ago, category: technology, tags: [ruby, rails]
+  # featured_post: published 2 hours ago, category: technology, tags: [ruby]
+  # related_ruby_post: published 3 days ago, category: technology, tags: [ruby, rails]
+  # related_rails_post: published 5 days ago, category: technology, tags: [rails]
+  # design_post: published 4 days ago, category: design, tags: [css]
+  # draft_post: draft, no category, no tags
+  # scheduled_post: scheduled for future, no category, no tags
+
+  test "related_posts returns posts with most shared tags first" do
+    post = posts(:published_post) # tags: ruby, rails
+    related = post.related_posts
+
+    # related_ruby_post shares 2 tags (ruby, rails) — should rank first
+    assert_equal posts(:related_ruby_post), related.first
+  end
+
+  test "related_posts excludes the current post" do
+    post = posts(:published_post)
+    related = post.related_posts
+
+    refute_includes related, post
+  end
+
+  test "related_posts excludes unpublished posts" do
+    post = posts(:published_post)
+    related = post.related_posts
+
+    refute_includes related, posts(:draft_post)
+    refute_includes related, posts(:scheduled_post)
+  end
+
+  test "related_posts returns up to limit posts" do
+    post = posts(:published_post)
+    related = post.related_posts(limit: 2)
+
+    assert_equal 2, related.size
+  end
+
+  test "related_posts backfills with category matches when insufficient tag matches" do
+    post = posts(:design_post) # category: design, tags: [javascript]
+    # No other posts share the css tag, so it should backfill
+    related = post.related_posts(limit: 3)
+
+    assert_equal 3, related.size
+  end
+
+  test "related_posts backfills with recent posts as last resort" do
+    post = posts(:design_post) # category: design — only design post
+    related = post.related_posts(limit: 3)
+
+    # No other posts share tags or category, so all 3 are recent backfills
+    assert_equal 3, related.size
+    related.each do |rp|
+      refute_equal post, rp
+    end
+  end
+
+  test "related_posts returns empty array when no other published posts exist" do
+    # Delete all posts except one
+    Post.where.not(id: posts(:published_post).id).destroy_all
+    related = posts(:published_post).related_posts
+
+    assert_empty related
+  end
+
+  test "previous_post returns the most recent post published before this one" do
+    post = posts(:published_post) # published 1 day ago
+    previous = post.previous_post
+
+    # related_ruby_post (3 days ago) is the next most recent before published_post
+    assert_equal posts(:related_ruby_post), previous
+  end
+
+  test "next_post returns the earliest post published after this one" do
+    post = posts(:published_post) # published 1 day ago
+    next_p = post.next_post
+
+    # featured_post (2 hours ago) is the next post after published_post
+    assert_equal posts(:featured_post), next_p
+  end
+
+  test "previous_post returns nil for the oldest published post" do
+    post = posts(:related_rails_post) # published 5 days ago — oldest
+    assert_nil post.previous_post
+  end
+
+  test "next_post returns nil for the newest published post" do
+    post = posts(:featured_post) # published 2 hours ago — newest
+    assert_nil post.next_post
+  end
+
+  test "previous_post and next_post exclude unpublished posts" do
+    post = posts(:featured_post) # newest published
+    assert_nil post.next_post # scheduled_post is in future but not published
+  end
+
+  test "related_posts for a post with no tags falls back to category" do
+    # Create a post with no tags but a category
+    post = Post.create!(title: "No Tags Post", user: users(:admin), category: categories(:technology),
+                        status: :published, published_at: 6.days.ago)
+
+    related = post.related_posts(limit: 3)
+    assert related.size > 0
+    assert related.all? { |rp| rp.id != post.id }
+  end
+end


### PR DESCRIPTION
## Summary

Adds content discovery features to the post show page: a "You might also like" related posts section and previous/next chronological navigation links. This improves reader engagement by providing pathways to discover more content after finishing a post.

## Changes

- **`Post::Discoverable` concern** — `related_posts` method uses a tag-overlap algorithm (primary), with category-match and recency fallbacks to always return up to 3 results. Also adds `previous_post` and `next_post` for chronological navigation among live posts.
- **`_related_posts.html.erb` partial** — Responsive 3-column card grid with featured image thumbnails, titles, and dates
- **`_post_navigation.html.erb` partial** — Previous/next links with post titles
- **`PostsController#show`** — Loads related posts and navigation data
- **Fixtures** — Added test posts with varied tag/category combinations for thorough coverage
- **13 new tests** covering tag matching, category fallback, recency fallback, prev/next navigation, and edge cases

## Documentation

- CLAUDE.md: Added `Post::Discoverable` to model organization examples
- README.md: No changes needed

## Testing

- Visit any published post and scroll to the bottom — related posts cards and prev/next links appear below the engagement section
- All 384 tests pass (13 new)
- Rubocop: no offenses on changed files
- Brakeman: no warnings
- Bundle/importmap audit: clean

Closes #27