### PR TITLE
Add breadcrumb structured data (schema.org) for SEO

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -96,4 +96,63 @@ module MetaTagsHelper
 
     json_ld_tag(data)
   end
+
+  def json_ld_breadcrumb_list(post)
+    items = []
+
+    # Home item
+    items << {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: root_url
+    }
+
+    # Category item (if post has a category)
+    if post.category.present?
+      items << {
+        "@type": "ListItem",
+        position: 2,
+        name: post.category.name,
+        item: category_url(post.category, slug: post.category.slug)
+      }
+    end
+
+    # Post item (always last, no URL)
+    position = items.size + 1
+    items << {
+      "@type": "ListItem",
+      position: position,
+      name: post.title
+    }
+
+    data = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: items
+    }
+
+    json_ld_tag(data)
+  end
+
+  def breadcrumb_navigation(post)
+    items = []
+
+    # Home
+    items << link_to("Home", root_path, class: "text-ink-blue hover:underline")
+
+    # Category
+    if post.category.present?
+      items << link_to(
+        post.category.name,
+        category_path(post.category, slug: post.category.slug),
+        class: "text-ink-blue hover:underline"
+      )
+    end
+
+    # Current page (not a link)
+    items << tag.span(post.title, class: "text-gray-600 dark:text-gray-400")
+
+    safe_join(items, " > ")
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,9 +3,15 @@
 <% content_for(:head) do %>
   <%= meta_tags_for_post(@post) %>
   <%= json_ld_for_post(@post) %>
+  <%= json_ld_breadcrumb_list(@post) %>
 <% end %>
 
 <article>
+  <%# Breadcrumb Navigation %>
+  <nav class="mb-4 text-sm text-gray-600 dark:text-gray-400" aria-label="breadcrumb">
+    <%= breadcrumb_navigation(@post) %>
+  </nav>
+
   <header class="mb-8 border-b border-gray-300 dark:border-gray-700 pb-8">
     <h1 class="font-display text-4xl font-bold leading-tight lg:text-5xl"><%= @post.title %></h1>
     <% if @post.subtitle.present? %>

--- a/test/helpers/meta_tags_helper_test.rb
+++ b/test/helpers/meta_tags_helper_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+class MetaTagsHelperTest < ActionView::TestCase
+  include MetaTagsHelper
+
+  setup do
+    @user = users(:admin)
+    @post = posts(:published_post)
+    @category = categories(:technology)
+  end
+
+  test "breadcrumb navigation with category" do
+    @post.category = @category
+    result = breadcrumb_navigation(@post)
+
+    assert_includes result, "Home"
+    assert_includes result, @category.name
+    assert_includes result, @post.title
+    assert_includes result, ">"
+    assert_includes result, 'href="/"'
+  end
+
+  test "breadcrumb navigation without category" do
+    post = posts(:draft_post)
+    post.category = nil
+    result = breadcrumb_navigation(post)
+
+    assert_includes result, "Home"
+    assert_includes result, post.title
+    assert_includes result, ">"
+    # Should not include category link
+    refute_includes result, "categories"
+  end
+
+  test "json_ld_breadcrumb_list with category" do
+    @post.category = @category
+    @post.save!
+    result = json_ld_breadcrumb_list(@post)
+
+    # Verify structure in string representation
+    assert_includes result, '"BreadcrumbList"'
+    assert_includes result, '"@context"'
+    assert_includes result, "https://schema.org"
+    assert_includes result, '"Home"'
+    assert_includes result, @category.name
+    assert_includes result, @post.title
+  end
+
+  test "json_ld_breadcrumb_list positions correct with category" do
+    @post.category = @category
+    @post.save!
+    result = json_ld_breadcrumb_list(@post)
+
+    # Should have 3 items: Home, Category, Post
+    # JSON format uses no spaces after colons
+    assert_includes result, '"position":1'
+    assert_includes result, '"position":2'
+    assert_includes result, '"position":3'
+  end
+
+  test "json_ld_breadcrumb_list positions correct without category" do
+    post = posts(:draft_post)
+    post.category = nil
+    post.save!
+    result = json_ld_breadcrumb_list(post)
+
+    # Should have 2 items: Home, Post
+    assert_includes result, '"position":1'
+    assert_includes result, '"position":2'
+    refute_includes result, '"position":3'
+  end
+
+  test "json_ld_breadcrumb_list includes home url" do
+    @post.category = @category
+    result = json_ld_breadcrumb_list(@post)
+
+    assert_includes result, root_url
+  end
+
+  test "json_ld_breadcrumb_list includes category url" do
+    @post.category = @category
+    @post.save!
+    result = json_ld_breadcrumb_list(@post)
+
+    category_url_str = category_url(@category, slug: @category.slug)
+    assert_includes result, category_url_str
+  end
+
+  test "json_ld_breadcrumb_list post item structure" do
+    @post.category = @category
+    result = json_ld_breadcrumb_list(@post)
+
+    # The post breadcrumb item should be a ListItem
+    assert_includes result, '"@type":"ListItem"'
+    assert_includes result, @post.title
+  end
+
+  test "json_ld_tag renders script with correct type" do
+    result = json_ld_tag({ "@type": "Organization", name: "Test" })
+    assert_includes result, "application/ld+json"
+    assert_includes result, "Organization"
+  end
+
+  test "breadcrumb navigation escapes html in titles" do
+    post = posts(:published_post)
+    post.title = "Test <script>alert('xss')</script>"
+    result = breadcrumb_navigation(post)
+
+    assert_includes result, "Home"
+    refute_includes result, "<script>"
+  end
+end


### PR DESCRIPTION
## Summary

Implements BreadcrumbList schema.org JSON-LD markup on post pages to improve search result appearance and click-through rates. Breadcrumb schema helps search engines understand site hierarchy and can display breadcrumb trails in search results (e.g., "Home > Technology > Post Title").

Includes both JSON-LD structured data for search engines and visible breadcrumb navigation UI for users.

## Changes

- Add `json_ld_breadcrumb_list(post)` helper to generate BreadcrumbList schema.org JSON-LD
  - Builds breadcrumb path: Home > Category (if present) > Post Title
  - Each item includes position and URL (except the current post)
- Add `breadcrumb_navigation(post)` helper for visible breadcrumb UI
  - Renders as styled navigation links
  - Uses Tailwind CSS for dark mode support
  - Properly escapes user content to prevent XSS
- Update post show view to include:
  - Breadcrumb JSON-LD in the `<head>` section
  - Visible breadcrumb navigation before the post header
- Comprehensive test coverage for both helpers
  - Tests with and without categories
  - Validates schema.org structure
  - Tests URL generation and positioning

## Test Plan

- [x] All existing tests pass (547 tests)
- [x] New breadcrumb helper tests pass (10 tests)
- [x] RuboCop linting passes with no offenses
- [x] Brakeman security scan passes with no warnings
- [x] No gem vulnerabilities detected
- [x] No JS dependency vulnerabilities

## Implementation Details

The breadcrumb path dynamically includes:
1. **Home** - Always first item, links to root
2. **Category** - Second item if the post has a category, links to category page
3. **Post Title** - Last item (current page), no URL

The breadcrumb navigation renders with aria-label for accessibility and uses semantic `<nav>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)