### PR TITLE
Email template customization

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,26 @@
 class ApplicationMailer < ActionMailer::Base
   default from: ENV.fetch("SMTP_FROM", "noreply@example.com")
   layout "mailer"
+
+  private
+
+  def load_email_branding
+    site = SiteSetting.current
+    @site_name = site.site_name
+    @email_accent_color = site.email_accent_color.presence || "#18181b"
+    @email_background_color = site.email_background_color.presence || "#f4f4f5"
+    @email_body_text_color = site.email_body_text_color.presence || "#3f3f46"
+    @email_heading_color = site.email_heading_color.presence || "#18181b"
+    @email_font_family = site.email_font_stack
+    @email_footer_text = site.email_footer_text.presence
+    @email_logo_url = site.email_header_logo_url
+  end
+
+  def generate_unsubscribe_url(subscriber)
+    token = Rails.application.message_verifier("unsubscribe").generate(
+      subscriber.id,
+      expires_in: 30.days
+    )
+    unsubscribe_url(token: token)
+  end
 end

--- a/app/mailers/newsletter_mailer.rb
+++ b/app/mailers/newsletter_mailer.rb
@@ -15,14 +15,4 @@ class NewsletterMailer < ApplicationMailer
 
     mail(to: subscriber.email, subject: newsletter.title)
   end
-
-  private
-
-  def generate_unsubscribe_url(subscriber)
-    token = Rails.application.message_verifier("unsubscribe").generate(
-      subscriber.id,
-      expires_in: 30.days
-    )
-    unsubscribe_url(token: token)
-  end
 end

--- a/app/mailers/post_notification_mailer.rb
+++ b/app/mailers/post_notification_mailer.rb
@@ -2,6 +2,12 @@ class PostNotificationMailer < ApplicationMailer
   def new_post(subscriber, post)
     @subscriber = subscriber
     @post = post
+    @unsubscribe_url = generate_unsubscribe_url(subscriber)
+    load_email_branding
+
+    headers["List-Unsubscribe"] = "<#{@unsubscribe_url}>"
+    headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
+
     mail(to: subscriber.email, subject: t("post_notification_mailer.new_post.subject", title: post.title))
   end
 end

--- a/app/mailers/subscriber_mailer.rb
+++ b/app/mailers/subscriber_mailer.rb
@@ -2,14 +2,14 @@ class SubscriberMailer < ApplicationMailer
   def confirmation(subscriber)
     @subscriber = subscriber
     @magic_link = subscriber_session_url(token: subscriber.auth_token)
-    @site_name = SiteSetting.current.site_name
+    load_email_branding
     mail(to: subscriber.email, subject: t("subscriber_mailer.confirmation.subject", site_name: @site_name))
   end
 
   def magic_link(subscriber)
     @subscriber = subscriber
     @magic_link = subscriber_session_url(token: subscriber.auth_token)
-    @site_name = SiteSetting.current.site_name
+    load_email_branding
     mail(to: subscriber.email, subject: t("subscriber_mailer.magic_link.sign_in_to", site_name: @site_name))
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -14,17 +14,21 @@
     <![endif]-->
   </head>
 
-  <body style="margin: 0; padding: 0; background-color: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f4f5;">
+  <body style="margin: 0; padding: 0; background-color: <%= @email_background_color || '#f4f4f5' %>; font-family: <%= @email_font_family || "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" %>;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: <%= @email_background_color || '#f4f4f5' %>;">
       <tr>
         <td align="center" style="padding: 24px 16px;">
           <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width: 600px; width: 100%;">
             <%# Header %>
             <tr>
               <td align="center" style="padding: 24px 0 16px;">
-                <span style="font-size: 20px; font-weight: 700; color: #18181b; text-decoration: none;">
-                  <%= @site_name || SiteSetting.current.site_name %>
-                </span>
+                <% if @email_logo_url.present? %>
+                  <img src="<%= @email_logo_url %>" alt="<%= @site_name %>" style="max-height: 48px; max-width: 200px; display: block;">
+                <% else %>
+                  <span style="font-size: 20px; font-weight: 700; color: <%= @email_heading_color || '#18181b' %>; text-decoration: none;">
+                    <%= @site_name || SiteSetting.current.site_name %>
+                  </span>
+                <% end %>
               </td>
             </tr>
 
@@ -38,7 +42,10 @@
             <%# Footer %>
             <tr>
               <td align="center" style="padding: 24px 0; color: #71717a; font-size: 13px; line-height: 20px;">
-                <p style="margin: 0 0 8px;">
+                <% if @email_footer_text.present? %>
+                  <p style="margin: 0 0 8px; color: #71717a;"><%= @email_footer_text %></p>
+                <% end %>
+                <p style="margin: 0 0 8px; color: #71717a;">
                   &copy; <%= Date.current.year %> <%= @site_name || SiteSetting.current.site_name %>
                 </p>
                 <% if @unsubscribe_url.present? %>

--- a/app/views/post_notification_mailer/new_post.html.erb
+++ b/app/views/post_notification_mailer/new_post.html.erb
@@ -1,9 +1,23 @@
-<h1><%= @post.title %></h1>
+<h1 style="margin: 0 0 8px; font-size: 22px; font-weight: 700; color: <%= @email_heading_color %>;">
+  <%= @post.title %>
+</h1>
 
 <% if @post.subtitle.present? %>
-  <p><em><%= @post.subtitle %></em></p>
+  <p style="margin: 0 0 12px; font-size: 16px; line-height: 24px; color: #71717a; font-style: italic;">
+    <%= @post.subtitle %>
+  </p>
 <% end %>
 
-<p><%= t('shared.by') %> <%= @post.user.display_name %></p>
+<p style="margin: 0 0 20px; font-size: 13px; color: #a1a1aa;">
+  <%= t('shared.by') %> <%= @post.user.display_name %>
+</p>
 
-<p><%= link_to t('post_notification_mailer.new_post.read_full_post'), post_url(@post, slug: @post.slug) %></p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 24px 0;">
+  <tr>
+    <td style="background-color: <%= @email_accent_color %>; border-radius: 6px; padding: 12px 24px;">
+      <a href="<%= post_url(@post, slug: @post.slug) %>" style="color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; display: inline-block;">
+        <%= t('post_notification_mailer.new_post.read_full_post') %>
+      </a>
+    </td>
+  </tr>
+</table>

--- a/app/views/subscriber_mailer/confirmation.html.erb
+++ b/app/views/subscriber_mailer/confirmation.html.erb
@@ -1,7 +1,21 @@
-<h1><%= t('subscriber_mailer.confirmation.welcome', site_name: @site_name) %></h1>
+<h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 700; color: <%= @email_heading_color %>;">
+  <%= t('subscriber_mailer.confirmation.welcome', site_name: @site_name) %>
+</h1>
 
-<p><%= t('subscriber_mailer.confirmation.thanks') %></p>
+<p style="margin: 0 0 16px; font-size: 15px; line-height: 24px; color: <%= @email_body_text_color %>;">
+  <%= t('subscriber_mailer.confirmation.thanks') %>
+</p>
 
-<p><%= link_to t('subscriber_mailer.confirmation.confirm_link'), @magic_link %></p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 24px 0;">
+  <tr>
+    <td style="background-color: <%= @email_accent_color %>; border-radius: 6px; padding: 12px 24px;">
+      <a href="<%= @magic_link %>" style="color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; display: inline-block;">
+        <%= t('subscriber_mailer.confirmation.confirm_link') %>
+      </a>
+    </td>
+  </tr>
+</table>
 
-<p><%= t('subscriber_mailer.confirmation.link_expiry') %></p>
+<p style="margin: 0; font-size: 13px; line-height: 20px; color: #71717a;">
+  <%= t('subscriber_mailer.confirmation.link_expiry') %>
+</p>

--- a/app/views/subscriber_mailer/magic_link.html.erb
+++ b/app/views/subscriber_mailer/magic_link.html.erb
@@ -1,7 +1,21 @@
-<h1><%= t('subscriber_mailer.magic_link.sign_in_to', site_name: @site_name) %></h1>
+<h1 style="margin: 0 0 16px; font-size: 22px; font-weight: 700; color: <%= @email_heading_color %>;">
+  <%= t('subscriber_mailer.magic_link.sign_in_to', site_name: @site_name) %>
+</h1>
 
-<p><%= t('subscriber_mailer.magic_link.click_to_sign_in') %></p>
+<p style="margin: 0 0 16px; font-size: 15px; line-height: 24px; color: <%= @email_body_text_color %>;">
+  <%= t('subscriber_mailer.magic_link.click_to_sign_in') %>
+</p>
 
-<p><%= link_to t('subscriber_mailer.magic_link.sign_in'), @magic_link %></p>
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 24px 0;">
+  <tr>
+    <td style="background-color: <%= @email_accent_color %>; border-radius: 6px; padding: 12px 24px;">
+      <a href="<%= @magic_link %>" style="color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; display: inline-block;">
+        <%= t('subscriber_mailer.magic_link.sign_in') %>
+      </a>
+    </td>
+  </tr>
+</table>
 
-<p><%= t('subscriber_mailer.magic_link.link_expiry') %></p>
+<p style="margin: 0; font-size: 13px; line-height: 20px; color: #71717a;">
+  <%= t('subscriber_mailer.magic_link.link_expiry') %>
+</p>

--- a/test/mailers/post_notification_mailer_test.rb
+++ b/test/mailers/post_notification_mailer_test.rb
@@ -10,4 +10,46 @@ class PostNotificationMailerTest < ActionMailer::TestCase
     assert_equal [ subscriber.email ], mail.to
     assert_includes mail.body.encoded, post.title
   end
+
+  test "new_post email uses branding colors" do
+    site = SiteSetting.current
+    site.update!(email_accent_color: "#ee1122", email_heading_color: "#aabbcc")
+    subscriber = subscribers(:confirmed)
+    post = posts(:published_post)
+    mail = PostNotificationMailer.new_post(subscriber, post)
+
+    assert_includes mail.body.encoded, "#ee1122"
+    assert_includes mail.body.encoded, "#aabbcc"
+  end
+
+  test "new_post email includes unsubscribe link" do
+    subscriber = subscribers(:confirmed)
+    post = posts(:published_post)
+    mail = PostNotificationMailer.new_post(subscriber, post)
+
+    assert_includes mail.body.encoded, "unsubscribe"
+    assert mail["List-Unsubscribe"].present?, "List-Unsubscribe header should be set"
+    assert_includes mail["List-Unsubscribe"].value, "unsubscribe"
+  end
+
+  test "new_post email uses custom background and font" do
+    site = SiteSetting.current
+    site.update!(email_background_color: "#fafafa", email_font_family: "georgia")
+    subscriber = subscribers(:confirmed)
+    post = posts(:published_post)
+    mail = PostNotificationMailer.new_post(subscriber, post)
+
+    assert_includes mail.body.encoded, "#fafafa"
+    assert_includes mail.body.encoded, "Georgia"
+  end
+
+  test "new_post email includes footer text when set" do
+    site = SiteSetting.current
+    site.update!(email_footer_text: "Thanks for reading our blog!")
+    subscriber = subscribers(:confirmed)
+    post = posts(:published_post)
+    mail = PostNotificationMailer.new_post(subscriber, post)
+
+    assert_includes mail.body.encoded, "Thanks for reading our blog!"
+  end
 end

--- a/test/mailers/subscriber_mailer_test.rb
+++ b/test/mailers/subscriber_mailer_test.rb
@@ -11,6 +11,17 @@ class SubscriberMailerTest < ActionMailer::TestCase
     assert_includes mail.body.encoded, subscriber.auth_token
   end
 
+  test "confirmation email uses branding colors" do
+    site = SiteSetting.current
+    site.update!(email_accent_color: "#ff5500", email_heading_color: "#112233")
+    subscriber = subscribers(:unconfirmed)
+    subscriber.generate_auth_token!
+    mail = SubscriberMailer.confirmation(subscriber)
+
+    assert_includes mail.body.encoded, "#ff5500"
+    assert_includes mail.body.encoded, "#112233"
+  end
+
   test "magic_link email" do
     subscriber = subscribers(:confirmed)
     subscriber.generate_auth_token!
@@ -19,5 +30,16 @@ class SubscriberMailerTest < ActionMailer::TestCase
     assert_equal "Sign in to #{SiteSetting.current.site_name}", mail.subject
     assert_equal [ subscriber.email ], mail.to
     assert_includes mail.body.encoded, subscriber.auth_token
+  end
+
+  test "magic_link email uses branding colors" do
+    site = SiteSetting.current
+    site.update!(email_accent_color: "#00aaff", email_body_text_color: "#334455")
+    subscriber = subscribers(:confirmed)
+    subscriber.generate_auth_token!
+    mail = SubscriberMailer.magic_link(subscriber)
+
+    assert_includes mail.body.encoded, "#00aaff"
+    assert_includes mail.body.encoded, "#334455"
   end
 end


### PR DESCRIPTION
## Summary

Applies the existing SiteSetting email branding (colors, fonts, logo, footer text) to all transactional emails — confirmation, magic link, and post notifications. Previously, branding was only used by the newsletter mailer while transactional emails used hardcoded styles.

## Changes

- Add `load_email_branding` helper to `ApplicationMailer` that loads all branding settings from `SiteSetting.current`
- Move `generate_unsubscribe_url` from `NewsletterMailer` to `ApplicationMailer` for reuse
- Update `layouts/mailer.html.erb` to use dynamic colors, font family, logo, and footer text
- Restyle `confirmation.html.erb`, `magic_link.html.erb`, and `new_post.html.erb` with branded CTA buttons and proper inline CSS
- Add `List-Unsubscribe` and `List-Unsubscribe-Post` headers to post notification emails
- Add branding assertion tests for all mailers (custom colors, fonts, footer text, unsubscribe link)

## Documentation

- README.md: No changes needed
- CLAUDE.md: No changes needed (email branding architecture already documented)

## Testing

- Configure email branding at `/admin/newsletter_settings` then trigger a confirmation or post notification email
- All 608 unit tests pass
- Rubocop: no offenses
- Brakeman: no warnings

Closes #36