### PR TITLE
Fix low-contrast buttons in dark mode

### DIFF
--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -87,7 +87,7 @@
   <% if @next_page %>
     <div class="mt-8 text-center">
       <%= link_to t('authors.show.load_more'), author_path(@identity, handle: @identity.handle, page: @next_page),
-            class: "inline-block rounded-md bg-charcoal px-6 py-2 text-sm font-medium text-white hover:bg-gray-700 transition-colors" %>
+            class: "inline-block rounded-md bg-charcoal dark:bg-gray-700 px-6 py-2 text-sm font-medium text-white dark:text-gray-100 hover:bg-gray-700 dark:hover:bg-gray-600 transition-colors" %>
     </div>
   <% end %>
 <% else %>

--- a/app/views/handles/_form.html.erb
+++ b/app/views/handles/_form.html.erb
@@ -6,6 +6,6 @@
             class: "block w-full rounded-md bg-white px-3 py-1.5 text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-ink-blue" %>
       <span id="handle_availability" data-handle-check-target="status"></span>
     </div>
-    <%= f.submit t('shared.save'), class: "rounded-md bg-charcoal px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 cursor-pointer" %>
+    <%= f.submit t('shared.save'), class: "rounded-md bg-charcoal dark:bg-gray-700 px-3 py-1.5 text-sm font-semibold text-white dark:text-gray-100 shadow-sm hover:bg-gray-700 dark:hover:bg-gray-600 cursor-pointer" %>
   <% end %>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -40,7 +40,7 @@
 <div class="mb-8 border-b border-gray-300 dark:border-gray-700 pb-8">
   <%= form_with url: posts_path, method: :get, data: { turbo_action: "advance" }, class: "flex items-center gap-3" do |f| %>
     <%= f.search_field :q, value: @query, placeholder: t('posts.index.search_placeholder'), class: "flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-white/5 px-4 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:border-ink-blue focus:outline-none focus:ring-1 focus:ring-ink-blue" %>
-    <%= f.submit t('shared.search'), class: "rounded-md bg-charcoal px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition-colors cursor-pointer" %>
+    <%= f.submit t('shared.search'), class: "rounded-md bg-charcoal dark:bg-gray-700 px-4 py-2 text-sm font-medium text-white dark:text-gray-100 hover:bg-gray-700 dark:hover:bg-gray-600 transition-colors cursor-pointer" %>
   <% end %>
 </div>
 

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -5,7 +5,7 @@
     <% end %>
     <%= f.email_field :email, placeholder: t('subscriptions.form.email_placeholder'), required: true,
           class: "flex-1 rounded-md bg-white dark:bg-white/5 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-ink-blue" %>
-    <%= f.submit t('shared.subscribe'), class: "rounded-md bg-charcoal px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-700 cursor-pointer" %>
+    <%= f.submit t('shared.subscribe'), class: "rounded-md bg-charcoal dark:bg-gray-700 px-4 py-2 text-sm font-semibold text-white dark:text-gray-100 shadow-sm hover:bg-gray-700 dark:hover:bg-gray-600 cursor-pointer" %>
   <% end %>
   <% if defined?(error) && error.present? %>
     <p class="mt-2 text-sm text-red-600 dark:text-red-400"><%= error %></p>


### PR DESCRIPTION
## Summary
- Add explicit dark mode styles to all public-facing buttons that use `bg-charcoal`
- The `bg-charcoal` class maps to a light color (`#e0def4`) in dark mode via CSS variable swapping, making white text on buttons nearly invisible
- Adds `dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600` to 4 buttons: search, subscribe, save handle, and load more

## Test plan
- [ ] Toggle dark mode and verify the Search button on the posts index is readable
- [ ] Verify the Subscribe button has good contrast in dark mode
- [ ] Verify the Save button on the handle form is readable in dark mode
- [ ] Verify the Load More button on author pages is readable in dark mode
- [ ] Confirm light mode buttons are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)