### PR TITLE
Post versioning / revision history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ app/models/user/authenticatable.rb    # module User::Authenticatable (concern)
 app/models/user/api_tokenable.rb     # module User::ApiTokenable (concern)
 app/models/user/passkey_authenticatable.rb # module User::PasskeyAuthenticatable (WebAuthn passkeys)
 app/models/post/discoverable.rb      # module Post::Discoverable (related posts, prev/next)
+app/models/post/versionable.rb      # module Post::Versionable (revision history, version cooldown)
+app/models/post_version.rb          # PostVersion: full snapshot of post content per version
 app/models/page.rb                    # class Page (custom static pages)
 app/models/page/sluggable.rb         # module Page::Sluggable (auto-generated URL slugs)
 app/models/page/publishable.rb       # module Page::Publishable (live scope, publish/draft)
@@ -96,7 +98,10 @@ Uses the **RubyLLM** gem for a unified LLM interface across providers (Claude fo
 Pages (`Page` model) provide custom static content at top-level URLs (`/:slug`). The catch-all route **must remain last** in `config/routes.rb` (after admin namespace and health check) to avoid intercepting other routes. Pages use `admin_page_editor` layout (simplified editor without AI/preview). Reserved slugs (admin, posts, feed, etc.) are validated at the model level. Published pages with `show_in_navigation: true` appear in the site header automatically via `Page.navigation` scope.
 
 ### Post Editor
-Uses the `admin_editor` layout. Autosave triggers on a 3-second debounce, serializing `#post_form` FormData. The editor drawer is a tabbed panel (AI + Settings). Settings fields use `form="post_form"` attribute with event listeners on the settings tab container to trigger autosave.
+Uses the `admin_editor` layout. Autosave triggers on a 3-second debounce, serializing `#post_form` FormData. The editor drawer is a tabbed panel (AI + Settings + Versions). Settings fields use `form="post_form"` attribute with event listeners on the settings tab container to trigger autosave.
+
+### Post Versioning
+`PostVersion` stores full snapshots (title, subtitle, content HTML, body plain text) on each save. Auto-versioning triggers on update with a 5-minute cooldown (`Post::Versionable`). Manual "Save version" button in the editor drawer's Versions tab. Diff view uses the `diffy` gem for plain-text comparison. "Restore" replaces the post's current content. Max 50 versions per post, pruned inline on version creation. Admin CRUD at `/admin/posts/:id/post_versions`.
 
 ### Key Stimulus Controllers
 `autosave`, `editor_drawer`, `tag_select`, `custom_select`, `streaming_markdown`, `ai_image_modal`, `typography_preview`, `markdown_preview`, `traffic_chart`, `segment_builder`

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem "mcp", "~> 0.8"
 # Rust-backed CommonMark/GFM markdown to HTML [https://github.com/gjtorikian/commonmarker]
 gem "commonmarker", "~> 2.3"
 
+# Plain-text diffs for post version history [https://github.com/samg/diffy]
+gem "diffy"
+
 # SendGrid Web API v3 for email delivery with tracking [https://github.com/sendgrid/sendgrid-ruby]
 gem "sendgrid-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    diffy (3.4.4)
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -472,6 +473,7 @@ DEPENDENCIES
   capybara
   commonmarker (~> 2.3)
   debug
+  diffy
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -536,6 +538,7 @@ CHECKSUMS
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  diffy (3.4.4) sha256=79384ab5ca82d0e115b2771f0961e27c164c456074bd2ec46b637ebf7b6e47e3
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506

--- a/app/controllers/admin/post_versions_controller.rb
+++ b/app/controllers/admin/post_versions_controller.rb
@@ -1,0 +1,36 @@
+module Admin
+  class PostVersionsController < BaseController
+    before_action :set_post
+    before_action :set_version, only: [ :show, :restore ]
+
+    def index
+      @versions = @post.post_versions.ordered.includes(:user)
+      render layout: false
+    end
+
+    def show
+      @diff = @version.diff_against_current
+      render layout: false
+    end
+
+    def create
+      @version = @post.create_version!(user: current_user)
+      redirect_to admin_post_post_versions_path(@post), notice: t("flash.admin.post_versions.created")
+    end
+
+    def restore
+      @post.restore_version!(@version)
+      redirect_to edit_admin_post_path(@post), notice: t("flash.admin.post_versions.restored")
+    end
+
+    private
+
+    def set_post
+      @post = Post.find_by!(slug: params[:post_id])
+    end
+
+    def set_version
+      @version = @post.post_versions.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -46,6 +46,7 @@ module Admin
 
     def update
       if @post.update(post_params)
+        @post.create_version_if_needed!(user: current_user)
         respond_to do |format|
           format.html { redirect_to edit_admin_post_path(@post), notice: t("flash.admin.posts.updated") }
           format.json { render json: post_json(@post), status: :ok }

--- a/app/jobs/prune_post_versions_job.rb
+++ b/app/jobs/prune_post_versions_job.rb
@@ -1,0 +1,13 @@
+class PrunePostVersionsJob < ApplicationJob
+  queue_as :default
+
+  def perform(post_id)
+    post = Post.find_by(id: post_id)
+    return unless post
+
+    excess_ids = post.post_versions.ordered
+      .offset(PostVersion::MAX_VERSIONS_PER_POST)
+      .pluck(:id)
+    PostVersion.where(id: excess_ids).delete_all if excess_ids.any?
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   include Publishable
   include Searchable
   include Discoverable
+  include Versionable
 
   enum :status, { draft: 0, scheduled: 1, published: 2 }
 

--- a/app/models/post/versionable.rb
+++ b/app/models/post/versionable.rb
@@ -1,0 +1,50 @@
+module Post::Versionable
+  extend ActiveSupport::Concern
+
+  VERSION_COOLDOWN = 5.minutes
+
+  included do
+    has_many :post_versions, dependent: :destroy
+  end
+
+  def create_version!(user:)
+    version = post_versions.create!(
+      user: user,
+      version_number: PostVersion.next_version_number_for(self),
+      title: title,
+      subtitle: subtitle,
+      content_html: content&.body&.to_html,
+      body_plain: body_plain
+    )
+    prune_old_versions!
+    version
+  end
+
+  def create_version_if_needed!(user:)
+    return unless version_cooldown_elapsed?
+
+    create_version!(user: user)
+  end
+
+  def version_cooldown_elapsed?
+    last_version = post_versions.ordered.first
+    last_version.nil? || last_version.created_at < VERSION_COOLDOWN.ago
+  end
+
+  def restore_version!(version)
+    update!(
+      title: version.title,
+      subtitle: version.subtitle,
+      content: version.content_html
+    )
+  end
+
+  private
+
+  def prune_old_versions!
+    excess_ids = post_versions.ordered
+      .offset(PostVersion::MAX_VERSIONS_PER_POST)
+      .pluck(:id)
+    post_versions.where(id: excess_ids).delete_all if excess_ids.any?
+  end
+end

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -1,0 +1,19 @@
+class PostVersion < ApplicationRecord
+  MAX_VERSIONS_PER_POST = 50
+
+  belongs_to :post
+  belongs_to :user
+
+  validates :version_number, presence: true, uniqueness: { scope: :post_id }
+  validates :title, presence: true
+
+  scope :ordered, -> { order(version_number: :desc) }
+
+  def self.next_version_number_for(post)
+    where(post: post).maximum(:version_number).to_i + 1
+  end
+
+  def diff_against_current
+    Diffy::Diff.new(body_plain.to_s, post.body_plain.to_s, context: 3)
+  end
+end

--- a/app/views/admin/post_versions/index.html.erb
+++ b/app/views/admin/post_versions/index.html.erb
@@ -1,0 +1,42 @@
+<%= turbo_frame_tag "version-detail" do %>
+  <div class="px-4 py-3 border-b border-gray-100">
+    <%= button_to t("admin.post_versions.index.save_version"),
+        admin_post_post_versions_path(@post),
+        method: :post,
+        class: "w-full rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 transition-colors" %>
+  </div>
+
+  <% if @versions.any? %>
+    <div class="divide-y divide-gray-100">
+      <% @versions.each do |version| %>
+        <div class="px-4 py-3 hover:bg-gray-50 transition-colors">
+          <div class="flex items-center justify-between">
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium text-gray-900 truncate">
+                v<%= version.version_number %> — <%= truncate(version.title, length: 40) %>
+              </p>
+              <p class="mt-0.5 text-xs text-gray-500">
+                <%= time_ago_in_words(version.created_at) %> <%= t("shared.ago") %>
+                · <%= version.user.display_name %>
+              </p>
+            </div>
+            <div class="ml-2 flex items-center gap-1">
+              <%= link_to admin_post_post_version_path(@post, version),
+                  class: "rounded px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 transition-colors",
+                  data: { turbo_frame: "version-detail" } do %>
+                <%= t("admin.post_versions.index.diff") %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="flex flex-col items-center justify-center py-12 text-center px-4">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <p class="mt-2 text-sm text-gray-500"><%= t("admin.post_versions.index.no_versions") %></p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/post_versions/show.html.erb
+++ b/app/views/admin/post_versions/show.html.erb
@@ -1,0 +1,53 @@
+<%= turbo_frame_tag "version-detail" do %>
+  <div class="border-b border-gray-200 px-4 py-3">
+    <div class="flex items-center justify-between">
+      <div>
+        <h3 class="text-sm font-semibold text-gray-900">
+          v<%= @version.version_number %>
+        </h3>
+        <p class="mt-0.5 text-xs text-gray-500">
+          <%= time_ago_in_words(@version.created_at) %> <%= t("shared.ago") %>
+          · <%= @version.user.display_name %>
+        </p>
+      </div>
+      <div class="flex items-center gap-2">
+        <%= button_to t("admin.post_versions.show.restore"),
+            restore_admin_post_post_version_path(@post, @version),
+            method: :post,
+            class: "rounded-md bg-blue-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-blue-500 transition-colors",
+            data: { turbo_confirm: t("admin.post_versions.show.restore_confirm") } %>
+        <%= link_to t("admin.post_versions.show.back"),
+            admin_post_post_versions_path(@post),
+            class: "rounded-md bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-200 transition-colors",
+            data: { turbo_frame: "version-detail" } %>
+      </div>
+    </div>
+  </div>
+
+  <% if @version.title != @post.title %>
+    <div class="border-b border-gray-100 px-4 py-2">
+      <p class="text-xs font-medium text-gray-500 mb-1"><%= t("admin.post_versions.show.title_change") %></p>
+      <p class="text-sm">
+        <span class="bg-red-100 text-red-800 line-through"><%= @version.title %></span>
+        &rarr;
+        <span class="bg-green-100 text-green-800"><%= @post.title %></span>
+      </p>
+    </div>
+  <% end %>
+
+  <div class="px-4 py-3 overflow-y-auto" style="max-height: calc(100vh - 16rem);">
+    <p class="text-xs font-medium text-gray-500 mb-2"><%= t("admin.post_versions.show.content_diff") %></p>
+    <div class="text-xs font-mono leading-relaxed whitespace-pre-wrap">
+      <% @diff.each_chunk do |chunk| %>
+        <% case chunk %>
+        <% when /^\+/ %>
+          <span class="bg-green-100 text-green-800"><%= chunk %></span>
+        <% when /^-/ %>
+          <span class="bg-red-100 text-red-800"><%= chunk %></span>
+        <% else %>
+          <span class="text-gray-600"><%= chunk %></span>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/posts/_editor_panel.html.erb
+++ b/app/views/admin/posts/_editor_panel.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (post:, ai_available:, chat: nil, messages: []) %>
+<%# locals: (post:, ai_available:, chat: nil, messages: [], versions_url: nil) %>
 
 <div data-editor-drawer-target="panel"
      class="fixed top-14 right-0 bottom-0 z-50 flex w-full translate-x-full flex-col border-l border-gray-200 bg-white shadow-xl transition-transform duration-300 ease-in-out sm:w-[28rem]">
@@ -42,6 +42,15 @@
             class="flex-1 border-b-2 px-4 py-2.5 text-center text-sm font-medium border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700">
       <%= t('admin.posts.editor_panel.settings') %>
     </button>
+    <% if post.persisted? %>
+      <button type="button"
+              data-editor-drawer-target="tabButton"
+              data-tab="versions"
+              data-action="click->editor-drawer#switchTab"
+              class="flex-1 border-b-2 px-4 py-2.5 text-center text-sm font-medium border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700">
+        <%= t('admin.posts.editor_panel.versions') %>
+      </button>
+    <% end %>
   </div>
 
   <% if ai_available %>
@@ -115,4 +124,18 @@
        class="hidden flex-1 overflow-y-auto">
     <%= render "admin/posts/settings_fields", post: post %>
   </div>
+
+  <% if post.persisted? %>
+    <%# Versions tab content %>
+    <div data-editor-drawer-target="tabContent" data-tab="versions"
+         class="hidden flex-1 flex flex-col overflow-hidden">
+      <turbo-frame id="version-detail" class="flex-1 flex flex-col overflow-y-auto"
+                   src="<%= admin_post_post_versions_path(post) %>"
+                   loading="lazy">
+        <div class="flex items-center justify-center py-12">
+          <p class="text-sm text-gray-500"><%= t("shared.loading") %></p>
+        </div>
+      </turbo-frame>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
         ai_empty_state: "Ask AI for writing help or use a quick action above."
         ai_placeholder: "Ask AI..."
         ai_send_hint: "Press Enter to send, Shift+Enter for new line"
+        versions: "Versions"
       featured_image_modal:
         title: "Generate Featured Image"
         suggesting_prompt: "Suggesting a prompt..."
@@ -591,6 +592,17 @@ en:
         generated_image: "Generated Featured Image"
         save_as_featured: "Save as Featured Image"
         regenerate: "Regenerate"
+    post_versions:
+      index:
+        save_version: "Save version"
+        diff: "Diff"
+        no_versions: "No versions yet. Versions are saved automatically as you edit."
+      show:
+        restore: "Restore"
+        restore_confirm: "Restore this version? Your current content will be replaced."
+        back: "Back"
+        title_change: "Title changed"
+        content_diff: "Content changes"
 
   # Mailers
   subscriber_mailer:
@@ -678,6 +690,9 @@ en:
         deleted: "Segment deleted."
       subscriber_labelings:
         already_assigned: "Label is already assigned to this subscriber."
+      post_versions:
+        created: "Version saved."
+        restored: "Version restored."
       categories:
         created: "Category created."
         updated: "Category updated."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -231,6 +231,7 @@ es:
         ai_empty_state: "Pide ayuda a la IA para escribir o usa una acción rápida arriba."
         ai_placeholder: "Pregunta a la IA..."
         ai_send_hint: "Presiona Enter para enviar, Shift+Enter para nueva línea"
+        versions: "Versiones"
       featured_image_modal:
         title: "Generar imagen destacada"
         suggesting_prompt: "Sugiriendo un prompt..."
@@ -587,6 +588,17 @@ es:
         generated_image: "Imagen destacada generada"
         save_as_featured: "Guardar como imagen destacada"
         regenerate: "Regenerar"
+    post_versions:
+      index:
+        save_version: "Guardar versión"
+        diff: "Diferencia"
+        no_versions: "Sin versiones aún. Las versiones se guardan automáticamente mientras editas."
+      show:
+        restore: "Restaurar"
+        restore_confirm: "¿Restaurar esta versión? Tu contenido actual será reemplazado."
+        back: "Volver"
+        title_change: "Título cambiado"
+        content_diff: "Cambios en el contenido"
 
   subscriber_mailer:
     confirmation:
@@ -671,6 +683,9 @@ es:
         deleted: "Segmento eliminado."
       subscriber_labelings:
         already_assigned: "La etiqueta ya está asignada a este suscriptor."
+      post_versions:
+        created: "Versión guardada."
+        restored: "Versión restaurada."
       categories:
         created: "Categoría creada."
         updated: "Categoría actualizada."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,11 @@ Rails.application.routes.draw do
       member do
         get :preview
       end
+      resources :post_versions, only: [ :index, :show, :create ] do
+        member do
+          post :restore
+        end
+      end
       resource :dashboard, only: [ :show ], controller: "post_dashboard"
       namespace :ai do
         resource :conversation, only: [ :show, :create ]

--- a/db/migrate/20260311171612_create_post_versions.rb
+++ b/db/migrate/20260311171612_create_post_versions.rb
@@ -1,0 +1,17 @@
+class CreatePostVersions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :post_versions do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.integer :version_number, null: false
+      t.string :title, null: false
+      t.string :subtitle
+      t.text :content_html
+      t.text :body_plain
+
+      t.timestamps
+    end
+
+    add_index :post_versions, [ :post_id, :version_number ], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -218,7 +218,18 @@ CREATE INDEX "index_newsletters_on_user_id" ON "newsletters" ("user_id") /*appli
 CREATE INDEX "index_newsletters_on_status" ON "newsletters" ("status") /*application='Prose'*/;
 CREATE INDEX "index_newsletters_on_scheduled_for" ON "newsletters" ("scheduled_for") /*application='Prose'*/;
 CREATE INDEX "index_newsletters_on_segment_id" ON "newsletters" ("segment_id") /*application='Prose'*/;
+CREATE TABLE IF NOT EXISTS "post_versions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "post_id" integer NOT NULL, "user_id" integer NOT NULL, "version_number" integer NOT NULL, "title" varchar NOT NULL, "subtitle" varchar, "content_html" text, "body_plain" text, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_5f7c4b6bbb"
+FOREIGN KEY ("post_id")
+  REFERENCES "posts" ("id")
+, CONSTRAINT "fk_rails_77830a0f52"
+FOREIGN KEY ("user_id")
+  REFERENCES "users" ("id")
+);
+CREATE INDEX "index_post_versions_on_post_id" ON "post_versions" ("post_id") /*application='Prose'*/;
+CREATE INDEX "index_post_versions_on_user_id" ON "post_versions" ("user_id") /*application='Prose'*/;
+CREATE UNIQUE INDEX "index_post_versions_on_post_id_and_version_number" ON "post_versions" ("post_id", "version_number") /*application='Prose'*/;
 INSERT INTO "schema_migrations" (version) VALUES
+('20260311171612'),
 ('20260311160003'),
 ('20260311160002'),
 ('20260311160001'),

--- a/test/controllers/admin/post_versions_controller_test.rb
+++ b/test/controllers/admin/post_versions_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class Admin::PostVersionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in_as(:admin)
+    @post = posts(:published_post)
+    @version = post_versions(:version_one)
+  end
+
+  test "GET index lists versions" do
+    get admin_post_post_versions_path(@post)
+    assert_response :success
+  end
+
+  test "GET show renders diff view" do
+    get admin_post_post_version_path(@post, @version)
+    assert_response :success
+  end
+
+  test "POST create saves a manual version" do
+    assert_difference "PostVersion.count", 1 do
+      post admin_post_post_versions_path(@post)
+    end
+    assert_redirected_to admin_post_post_versions_path(@post)
+  end
+
+  test "POST restore restores a version" do
+    post restore_admin_post_post_version_path(@post, @version)
+    assert_redirected_to edit_admin_post_path(@post)
+
+    @post.reload
+    assert_equal "Original Title", @post.title
+  end
+
+  test "requires authentication" do
+    delete admin_session_path
+    get admin_post_post_versions_path(@post)
+    assert_response :redirect
+  end
+end

--- a/test/controllers/admin/setup_controller_test.rb
+++ b/test/controllers/admin/setup_controller_test.rb
@@ -92,6 +92,7 @@ class Admin::SetupControllerTest < ActionDispatch::IntegrationTest
     PostView.delete_all
     PostTag.delete_all
     Chat.delete_all
+    PostVersion.delete_all
     Post.delete_all
     Page.delete_all
     Session.delete_all

--- a/test/fixtures/post_versions.yml
+++ b/test/fixtures/post_versions.yml
@@ -1,0 +1,19 @@
+version_one:
+  post: published_post
+  user: admin
+  version_number: 1
+  title: "Original Title"
+  subtitle: "Original subtitle"
+  content_html: "<p>Original content of the post.</p>"
+  body_plain: "Original content of the post."
+  created_at: <%= 2.hours.ago %>
+
+version_two:
+  post: published_post
+  user: admin
+  version_number: 2
+  title: "Published Post"
+  subtitle: "A published article"
+  content_html: "<p>Updated content of the post.</p>"
+  body_plain: "Updated content of the post."
+  created_at: <%= 1.hour.ago %>

--- a/test/jobs/prune_post_versions_job_test.rb
+++ b/test/jobs/prune_post_versions_job_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class PrunePostVersionsJobTest < ActiveJob::TestCase
+  test "removes excess versions beyond the limit" do
+    post = posts(:draft_post)
+    user = users(:admin)
+
+    (PostVersion::MAX_VERSIONS_PER_POST + 3).times do |i|
+      post.post_versions.create!(
+        user: user,
+        version_number: i + 1,
+        title: "Version #{i + 1}",
+        body_plain: "Content"
+      )
+    end
+
+    assert_equal PostVersion::MAX_VERSIONS_PER_POST + 3, post.post_versions.count
+
+    PrunePostVersionsJob.perform_now(post.id)
+
+    assert_equal PostVersion::MAX_VERSIONS_PER_POST, post.post_versions.count
+    # Newest versions should be kept
+    assert_equal PostVersion::MAX_VERSIONS_PER_POST + 3, post.post_versions.ordered.first.version_number
+  end
+
+  test "does nothing when under the limit" do
+    post = posts(:published_post)
+    assert_no_difference "PostVersion.count" do
+      PrunePostVersionsJob.perform_now(post.id)
+    end
+  end
+
+  test "handles missing post gracefully" do
+    assert_nothing_raised do
+      PrunePostVersionsJob.perform_now(0)
+    end
+  end
+end

--- a/test/models/post/versionable_test.rb
+++ b/test/models/post/versionable_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class Post::VersionableTest < ActiveSupport::TestCase
+  setup do
+    @post = posts(:published_post)
+    @user = users(:admin)
+  end
+
+  test "create_version! creates a new version with correct attributes" do
+    assert_difference "PostVersion.count", 1 do
+      version = @post.create_version!(user: @user)
+      assert_equal @post.title, version.title
+      assert_equal @post.subtitle, version.subtitle
+      assert_equal @post.body_plain, version.body_plain
+      assert_equal 3, version.version_number
+    end
+  end
+
+  test "create_version_if_needed! creates version when cooldown elapsed" do
+    # Backdate existing versions so cooldown has elapsed
+    @post.post_versions.update_all(created_at: 10.minutes.ago)
+
+    assert_difference "PostVersion.count", 1 do
+      @post.create_version_if_needed!(user: @user)
+    end
+  end
+
+  test "create_version_if_needed! skips when cooldown not elapsed" do
+    @post.post_versions.update_all(created_at: 1.minute.ago)
+
+    assert_no_difference "PostVersion.count" do
+      @post.create_version_if_needed!(user: @user)
+    end
+  end
+
+  test "create_version_if_needed! creates version when no versions exist" do
+    post = posts(:draft_post)
+    assert_difference "PostVersion.count", 1 do
+      post.create_version_if_needed!(user: @user)
+    end
+  end
+
+  test "version_cooldown_elapsed? returns true with no versions" do
+    post = posts(:draft_post)
+    assert post.version_cooldown_elapsed?
+  end
+
+  test "version_cooldown_elapsed? returns false within cooldown" do
+    @post.post_versions.update_all(created_at: 1.minute.ago)
+    assert_not @post.version_cooldown_elapsed?
+  end
+
+  test "restore_version! restores post content from version" do
+    version = post_versions(:version_one)
+    @post.restore_version!(version)
+    @post.reload
+
+    assert_equal "Original Title", @post.title
+    assert_equal "Original subtitle", @post.subtitle
+  end
+
+  test "prune_old_versions! removes excess versions" do
+    post = posts(:draft_post)
+    (PostVersion::MAX_VERSIONS_PER_POST + 5).times do |i|
+      post.post_versions.create!(
+        user: @user,
+        version_number: i + 1,
+        title: "Version #{i + 1}",
+        body_plain: "Content #{i + 1}"
+      )
+    end
+
+    assert_equal PostVersion::MAX_VERSIONS_PER_POST + 5, post.post_versions.count
+    post.create_version!(user: @user)
+    assert_equal PostVersion::MAX_VERSIONS_PER_POST, post.post_versions.count
+  end
+end

--- a/test/models/post_version_test.rb
+++ b/test/models/post_version_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class PostVersionTest < ActiveSupport::TestCase
+  test "belongs to post and user" do
+    version = post_versions(:version_one)
+    assert_equal posts(:published_post), version.post
+    assert_equal users(:admin), version.user
+  end
+
+  test "validates presence of version_number" do
+    version = PostVersion.new(post: posts(:published_post), user: users(:admin), title: "Test")
+    assert_not version.valid?
+    assert_includes version.errors[:version_number], "can't be blank"
+  end
+
+  test "validates uniqueness of version_number scoped to post" do
+    version = PostVersion.new(
+      post: posts(:published_post),
+      user: users(:admin),
+      version_number: 1,
+      title: "Duplicate"
+    )
+    assert_not version.valid?
+    assert_includes version.errors[:version_number], "has already been taken"
+  end
+
+  test "validates presence of title" do
+    version = PostVersion.new(post: posts(:published_post), user: users(:admin), version_number: 99)
+    assert_not version.valid?
+    assert_includes version.errors[:title], "can't be blank"
+  end
+
+  test "ordered scope returns newest first" do
+    versions = PostVersion.where(post: posts(:published_post)).ordered
+    assert_equal 2, versions.first.version_number
+    assert_equal 1, versions.last.version_number
+  end
+
+  test "next_version_number_for returns correct number" do
+    assert_equal 3, PostVersion.next_version_number_for(posts(:published_post))
+    assert_equal 1, PostVersion.next_version_number_for(posts(:draft_post))
+  end
+
+  test "diff_against_current returns a Diffy::Diff" do
+    version = post_versions(:version_one)
+    diff = version.diff_against_current
+    assert_instance_of Diffy::Diff, diff
+  end
+end


### PR DESCRIPTION
## Summary

Adds post versioning with full revision history — auto-versioning on save with 5-minute cooldown, manual "Save version" button, plain-text diff view, and one-click restore. Max 50 versions per post.

## Changes

- **PostVersion model** with full content snapshots (title, subtitle, content HTML, body plain text)
- **Post::Versionable concern** with `create_version!`, `create_version_if_needed!` (cooldown), `restore_version!`, and inline pruning
- **Admin::PostVersionsController** with index, show (diff), create (manual), and restore actions
- **Versions tab** in the editor drawer (alongside AI + Settings), loaded via Turbo Frame
- **Diff view** using `diffy` gem for plain-text comparison with color-coded additions/deletions
- **PrunePostVersionsJob** for background pruning
- **Auto-versioning** triggered in posts controller update action
- i18n strings for English and Spanish

## Documentation

- CLAUDE.md: Added PostVersion model, Post::Versionable concern, and Post Versioning section
- README.md: No changes needed (admin-only feature)

## Testing

- 23 new tests covering model validations, version creation, cooldown logic, pruning, restore, controller actions, and job behavior
- All 780 tests pass
- Rubocop: no offenses on new files
- Brakeman: no warnings
- Manual testing: open the post editor, click the drawer, switch to "Versions" tab

Closes #50